### PR TITLE
fix: correct routing and dev script details in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ NODE_ENV=development npx tsx ./bin/www   # Express on :3000
 npx vite                                  # Vite on :3001
 ```
 
-Do NOT use `pnpm run dev` directly (it uses `nodemon` which invokes `node`, not `tsx`). If you need file watching, use `nodemon --exec tsx ./bin/www`.
+`pnpm run dev` uses `concurrently` to run both Vite and `nodemon --exec tsx`, which works correctly. You can also start servers separately as shown above.
 
 **Important**: Never leave compiled `.js` files next to `.ts` files in `src/shared/`. Vite will serve the `.js` files (CJS format) instead of transforming the `.ts` files (ESM), causing the frontend to break silently (merchant page stuck on spinner).
 
@@ -37,7 +37,8 @@ Both use the same migrations/seeds: `npx knex migrate:latest --knexfile db/knexf
 
 ### Routing
 
-- The merchant dashboard route is `/merchant` (exact match, not `/merchant/:id`). The component hardcodes `merchant_id = 3`.
+- The merchant dashboard route is `/merchant-dashboard/:uuid` (e.g. `/merchant-dashboard/a0000001-0001-0001-0001-000000000001`).
+- The online ordering route is `/online-ordering/:slug` (e.g. `/online-ordering/instep-cafe-new-york-10001-lunch-menu`).
 - The `pnpm run type-check` has pre-existing TypeScript errors in the client code; the project compiles and runs fine via Vite regardless.
 
 ### pnpm build scripts
@@ -51,6 +52,13 @@ Merchant accounts are **only** creatable via the admin script — not via UI or 
 ```bash
 pnpm run create-merchant "Business Name" [--address "addr"] [--postal-code 94105] [--description "desc"] [--type cafe]
 ```
+
+### Seed data for testing
+
+When using SQLite mode (`DB_CLIENT=sqlite3`), seed merchants have these UUIDs (see `README.md` for full list):
+- Merchant 1 (INSTEP Cafe): UUID `a0000001-0001-0001-0001-000000000001`
+- Merchant 2: UUID `a0000002-0002-0002-0002-000000000002`
+- Published menu slug: `instep-cafe-new-york-10001-lunch-menu`
 
 ### Optional integrations
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes inaccuracies in `AGENTS.md` discovered during environment setup:

- **Routing**: Updated merchant dashboard route from `/merchant` to the actual `/merchant-dashboard/:uuid` pattern, and added the online ordering route `/online-ordering/:slug`
- **Dev script**: Corrected the claim that `pnpm run dev` uses `node` — it already uses `nodemon --exec tsx`
- **Seed data**: Added a quick-reference section with seed merchant UUIDs and menu slugs for testing

## Demo

[eggroll_pos_demo.mp4](https://cursor.com/agents/bc-39329aec-aa9e-4335-a43b-00272e74b4d6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Feggroll_pos_demo.mp4)

Full environment demo showing homepage, merchant dashboard, online ordering menu, and contact form submission.

[Merchant dashboard with active orders](https://cursor.com/agents/bc-39329aec-aa9e-4335-a43b-00272e74b4d6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmerchant_dashboard.webp)
[Online ordering menu](https://cursor.com/agents/bc-39329aec-aa9e-4335-a43b-00272e74b4d6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fonline_menu.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-39329aec-aa9e-4335-a43b-00272e74b4d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-39329aec-aa9e-4335-a43b-00272e74b4d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

