### PR TITLE
Knex upgrade PR 1: insert-id helpers and model normalization

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build:all": "npm run build && npm run build:server",
     "preview": "vite preview",
     "type-check": "tsc --noEmit",
-    "test": "DB_CLIENT=sqlite3 DB_FILENAME=test.db NODE_ENV=development mocha specs/**/*",
+    "test": "DB_CLIENT=sqlite3 DB_FILENAME=test.db NODE_ENV=development mocha specs/**/* --exit",
     "test:pg": "NODE_ENV=development mocha specs/**/*",
     "create-merchant": "node scripts/create-merchant.js",
     "screenshots:merchant": "node scripts/capture-merchant-screenshots.js",

--- a/specs/db/insert-id.spec.ts
+++ b/specs/db/insert-id.spec.ts
@@ -1,0 +1,33 @@
+import { expect } from 'chai';
+import { extractInsertId, extractReturningRow } from '../../src/server/db/insert-id';
+
+describe('extractInsertId', () => {
+  it('extracts a bare number (SQLite last insert id)', () => {
+    expect(extractInsertId([42])).to.equal(42);
+  });
+
+  it('extracts id from Knex 1+ returning object', () => {
+    expect(extractInsertId([{ id: 7 }])).to.equal(7);
+  });
+
+  it('extracts a single object without array wrapper', () => {
+    expect(extractInsertId({ id: 3 })).to.equal(3);
+  });
+
+  it('throws when result is empty', () => {
+    expect(() => extractInsertId([])).to.throw('Could not extract insert id');
+  });
+});
+
+describe('extractReturningRow', () => {
+  it('returns the first row object', () => {
+    const row = extractReturningRow<{ id: number; name: string }>([
+      { id: 1, name: 'Latte' },
+    ]);
+    expect(row).to.deep.equal({ id: 1, name: 'Latte' });
+  });
+
+  it('returns undefined for empty results', () => {
+    expect(extractReturningRow([])).to.equal(undefined);
+  });
+});

--- a/specs/models/customers.spec.ts
+++ b/specs/models/customers.spec.ts
@@ -6,6 +6,10 @@ import Customers from '../../src/server/models/customers';
 const migrationsDir = path.resolve(__dirname, '../../db/migrations');
 
 async function resetCustomers() {
+  await db('whatsapp_opt_ins').del();
+  await db('receipts').del();
+  await db('line_items').del();
+  await db('orders').del();
   await db('customers').del();
   await db.raw("DELETE FROM sqlite_sequence WHERE name = 'customers'");
 }
@@ -23,19 +27,18 @@ describe('Customers', () => {
     beforeEach(resetCustomers);
 
     it('creates a customer and returns the new id', async () => {
-      const ids = await Customers.create({ name: 'Alice' });
+      const id = await Customers.create({ name: 'Alice' });
 
-      expect(ids).to.be.an('array');
-      expect(ids[0]).to.be.a('number');
+      expect(id).to.be.a('number');
 
-      const customer = await Customers.getWithId(ids[0]);
+      const customer = await Customers.getWithId(id);
       expect(customer).to.exist;
       expect(customer!.name).to.equal('Alice');
     });
 
     it('sets created_at automatically', async () => {
-      const ids = await Customers.create({ name: 'Bob' });
-      const customer = await Customers.getWithId(ids[0]);
+      const id = await Customers.create({ name: 'Bob' });
+      const customer = await Customers.getWithId(id);
 
       expect(customer!.created_at).to.exist;
     });
@@ -48,8 +51,7 @@ describe('Customers', () => {
 
     before(async () => {
       await resetCustomers();
-      const ids = await Customers.create({ name: 'Carol' });
-      customerId = ids[0];
+      customerId = await Customers.create({ name: 'Carol' });
     });
 
     it('returns a customer by id', async () => {
@@ -77,8 +79,8 @@ describe('Customers', () => {
 
   describe('type narrowing', () => {
     it('narrows the type after null check', async () => {
-      const ids = await Customers.create({ name: 'TypeTest' });
-      const customer = await Customers.getWithId(ids[0]);
+      const id = await Customers.create({ name: 'TypeTest' });
+      const customer = await Customers.getWithId(id);
 
       // verify the shape matches CustomerRow
       expect(customer).to.have.property('id');

--- a/specs/models/menus.spec.ts
+++ b/specs/models/menus.spec.ts
@@ -23,6 +23,11 @@ describe('Menus', () => {
     // Reset tables to a clean state (respect FK order: children first)
     await db('menu_menu_items').del();
     await db('menus').del();
+    await db('whatsapp_opt_ins').del();
+    await db('receipts').del();
+    await db('line_items').del();
+    await db('orders').del();
+    await db('customers').del();
     await db('menu_items').del();
     await db('merchants').del();
     await db.raw("DELETE FROM sqlite_sequence WHERE name IN ('menus','menu_items','merchants')");

--- a/specs/routes/createOrder.e2e.spec.ts
+++ b/specs/routes/createOrder.e2e.spec.ts
@@ -1,8 +1,10 @@
 import { expect } from 'chai';
 import path from 'path';
 import request from 'supertest';
-import db from '../../src/server/models/db';
+import { createRequire } from 'module';
 
+const require = createRequire(import.meta.url);
+const db = require('../../src/server/models/db');
 const app = require('../../src/server/index');
 
 const migrationsDir = path.resolve(__dirname, '../../db/migrations');
@@ -20,6 +22,8 @@ let modNoCream: number;
 async function resetAll() {
   await db('line_item_modifiers').del();
   await db('line_items').del();
+  await db('whatsapp_opt_ins').del();
+  await db('receipts').del();
   await db('orders').del();
   await db('customers').del();
   await db('menu_item_modifiers').del();

--- a/specs/services/createOrder.spec.ts
+++ b/specs/services/createOrder.spec.ts
@@ -11,6 +11,8 @@ const MERCHANT_HASH = 'mc_testcafe01';
 async function resetAll() {
   await db('line_item_modifiers').del();
   await db('line_items').del();
+  await db('whatsapp_opt_ins').del();
+  await db('receipts').del();
   await db('orders').del();
   await db('customers').del();
   await db('menu_item_modifiers').del();

--- a/src/server/db/dialect.ts
+++ b/src/server/db/dialect.ts
@@ -1,0 +1,6 @@
+/**
+ * Prefer DB_CLIENT over Knex internals — stable across Knex 0.x–3.x.
+ */
+export function isSqlite(): boolean {
+  return process.env.DB_CLIENT === 'sqlite3';
+}

--- a/src/server/db/insert-id.ts
+++ b/src/server/db/insert-id.ts
@@ -1,0 +1,36 @@
+/**
+ * Normalize Knex insert/returning results across drivers and Knex versions.
+ *
+ * - Knex 0.20 + PostgreSQL: returning('id') → [42]
+ * - Knex 1.0+: returning('id') → [{ id: 42 }]
+ * - SQLite: returning() is unsupported; insert may return [lastRowId]
+ */
+export function extractInsertId(result: unknown): number {
+  const row = Array.isArray(result) ? result[0] : result;
+
+  if (typeof row === 'number' && !Number.isNaN(row)) {
+    return row;
+  }
+
+  if (row && typeof row === 'object' && 'id' in row) {
+    const id = Number((row as { id: unknown }).id);
+    if (!Number.isNaN(id)) {
+      return id;
+    }
+  }
+
+  throw new Error('Could not extract insert id from Knex result');
+}
+
+/**
+ * First row from .returning('*') or .returning([...columns]).
+ */
+export function extractReturningRow<T extends Record<string, unknown>>(
+  result: unknown
+): T | undefined {
+  const row = Array.isArray(result) ? result[0] : result;
+  if (row && typeof row === 'object') {
+    return row as T;
+  }
+  return undefined;
+}

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -54,7 +54,7 @@ app.get("/r/:receiptId", async (req, res) => {
 });
 
 /* This should come after all other routes */
-app.use("/*", ReactRouter);
+app.use("/{*splat}", ReactRouter);
 
 // catch 404 and forward to error handler
 app.use(function (req, res, next) {

--- a/src/server/models/customers.ts
+++ b/src/server/models/customers.ts
@@ -1,5 +1,6 @@
 import db from './db';
 import type { CustomerRow, CustomerCreateParams } from '../../shared/customers';
+import { extractInsertId } from '../db/insert-id';
 
 const Table = () => db('customers');
 
@@ -15,14 +16,13 @@ class Customers {
     psid = null,
     mobile_phone = null,
     email = null,
-  }: CustomerCreateParams): Promise<number[]> {
+  }: CustomerCreateParams): Promise<number> {
     const row: Record<string, unknown> = { name };
     if (psid != null) row.psid = psid;
     if (mobile_phone != null) row.mobile_phone = mobile_phone;
     if (email != null) row.email = email;
-    return Table()
-      .insert(row)
-      .returning('id');
+    const result = await Table().insert(row).returning('id');
+    return extractInsertId(result);
   }
 
   static async updateContact(

--- a/src/server/models/lineItems.js
+++ b/src/server/models/lineItems.js
@@ -1,4 +1,5 @@
 const db = require('./db');
+const { extractInsertId } = require('../db/insert-id');
 
 const T = () => db('line_items');
 const ModifiersT = () => db('line_item_modifiers');
@@ -12,7 +13,7 @@ class LineItems {
       menu_item_id: menuItemId,
       quantity,
     }).returning('id');
-    return res[0];
+    return extractInsertId(res);
   }
 
   static async addModifiers(lineItemId, modifierIds) {
@@ -33,10 +34,11 @@ class LineItems {
   }
 
   static async update(id, params) {
-    return await T()
+    const res = await T()
       .update({...params})
       .where('id', id)
-      .returning('id')
+      .returning('id');
+    return extractInsertId(res);
   }
 
   static async remove({lineItemId, orderId}) {

--- a/src/server/models/menu_categories.ts
+++ b/src/server/models/menu_categories.ts
@@ -1,4 +1,5 @@
 import db from './db';
+import { extractInsertId } from '../db/insert-id';
 
 const T = () => db('menu_categories');
 
@@ -21,11 +22,12 @@ class MenuCategories {
     name: string;
     sortOrder?: number;
   }) {
-    const [id] = await T().insert({
+    const result = await T().insert({
       merchant_id: params.merchantId ?? null,
       name: params.name,
       sort_order: params.sortOrder ?? 0,
     });
+    const id = extractInsertId(result);
     return T().where('id', id).first();
   }
 

--- a/src/server/models/menu_items.js
+++ b/src/server/models/menu_items.js
@@ -1,4 +1,5 @@
 const db = require('./db');
+const { extractReturningRow } = require('../db/insert-id');
 
 const T = () => db('menu_items');
 
@@ -25,7 +26,7 @@ class MenuItem {
     const priceCents = params.priceCents ?? params.price_cents;
     const isActive = params.isActive ?? params.is_active ?? true;
     const sortOrder = params.sortOrder ?? params.sort_order ?? 0;
-    const [row] = await T()
+    const result = await T()
       .insert({
         merchant_id: merchantId,
         name,
@@ -35,7 +36,7 @@ class MenuItem {
         sort_order: sortOrder,
       })
       .returning('*');
-    return row;
+    return extractReturningRow(result);
   }
 
   static async update(id, params) {
@@ -45,11 +46,11 @@ class MenuItem {
       if (params[k] !== undefined) updates[k] = params[k];
     }
     if (Object.keys(updates).length === 0) return null;
-    const [row] = await T()
+    const result = await T()
       .update(updates)
       .where('id', id)
       .returning('*');
-    return row;
+    return extractReturningRow(result);
   }
 
   static async delete(id) {

--- a/src/server/models/merchants.ts
+++ b/src/server/models/merchants.ts
@@ -1,6 +1,7 @@
 import crypto from 'crypto';
 import db from './db';
 import type { MerchantRow, MerchantCreateParams, MerchantUpdateParams } from '../../shared/merchants';
+import { extractInsertId } from '../db/insert-id';
 
 const T = () => db('merchants');
 
@@ -44,17 +45,19 @@ class Merchants {
    * Create merchant. For admin use only — do NOT expose via API or UI.
    * Use: pnpm run create-merchant "Business Name"
    */
-  static async create(params: MerchantCreateParams): Promise<number[]> {
+  static async create(params: MerchantCreateParams): Promise<number> {
     const hash_id = generateHashId();
-    return T().insert({ ...params, hash_id }).returning('id');
+    const result = await T().insert({ ...params, hash_id }).returning('id');
+    return extractInsertId(result);
   }
 
-  static async update(id: number, params: MerchantUpdateParams): Promise<number[]> {
+  static async update(id: number, params: MerchantUpdateParams): Promise<number> {
     console.log(`Updating merchant ${id} with `, params);
-    return T()
+    const result = await T()
       .update(params)
       .where('id', id)
       .returning('id');
+    return extractInsertId(result);
   }
 
   static async getByZip(zipCode: string): Promise<MerchantRow[]> {

--- a/src/server/models/modifiers.js
+++ b/src/server/models/modifiers.js
@@ -1,4 +1,5 @@
 const db = require('./db');
+const { extractReturningRow } = require('../db/insert-id');
 
 const T = () => db('modifiers');
 const JunctionT = () => db('menu_item_modifiers');
@@ -13,7 +14,7 @@ class Modifiers {
   }
 
   static async create({ merchantId, name, priceAdjustmentCents = 0, sortOrder = 0 }) {
-    const [row] = await T()
+    const result = await T()
       .insert({
         merchant_id: merchantId,
         name,
@@ -22,7 +23,7 @@ class Modifiers {
         updated_at: db.fn.now(),
       })
       .returning('*');
-    return row;
+    return extractReturningRow(result);
   }
 
   static async update(id, { name, priceAdjustmentCents, sortOrder }) {
@@ -32,11 +33,11 @@ class Modifiers {
     if (sortOrder !== undefined) updates.sort_order = sortOrder;
     updates.updated_at = db.fn.now();
 
-    const [row] = await T()
+    const result = await T()
       .update(updates)
       .where('id', id)
       .returning('*');
-    return row;
+    return extractReturningRow(result);
   }
 
   static async getById(id) {

--- a/src/server/models/orders.ts
+++ b/src/server/models/orders.ts
@@ -2,6 +2,8 @@ import db from './db';
 import * as uuid from 'uuid';
 import camelcaseKeys from 'camelcase-keys';
 import { Status, OrderStatus, OrderType } from '../../shared/orders';
+import { isSqlite } from '../db/dialect';
+import { extractReturningRow } from '../db/insert-id';
 
 const Table = () => db('orders');
 const MenuItemsTable = () => db('menu_items');
@@ -77,12 +79,11 @@ class Order {
   }
 
   static async list(merchantId: number, filter: OrderFilter) {
-    const isSqlite = (db as any).client.config.client === 'sqlite3';
-    const pickupEtaExpr = isSqlite
+    const pickupEtaExpr = isSqlite()
       ? `datetime(orders.confirmed_at, '+' || orders.pickup_in || ' minutes') as pickup_eta`
       : `orders.confirmed_at + (orders.pickup_in * interval '1 minute') as pickup_eta`;
-    const dateExpr = isSqlite ? 'date(orders.created_at)' : '(orders.created_at)::date';
-    const dateExprO2 = isSqlite ? 'date(o2.created_at)' : '(o2.created_at)::date';
+    const dateExpr = isSqlite() ? 'date(orders.created_at)' : '(orders.created_at)::date';
+    const dateExprO2 = isSqlite() ? 'date(o2.created_at)' : '(o2.created_at)::date';
     const displayNumberExpr = `(SELECT COUNT(*) FROM orders o2 WHERE o2.merchant_id = orders.merchant_id AND ${dateExprO2} = ${dateExpr} AND o2.id <= orders.id) as display_number`;
 
     let query = db
@@ -119,14 +120,14 @@ class Order {
       .where('merchant_id', merchantId);
 
     if (filter.startDate) {
-      if (isSqlite) {
+      if (isSqlite()) {
         query = query.andWhereRaw('date(created_at) >= date(?)', [filter.startDate]);
       } else {
         query = query.andWhereRaw('(created_at)::date >= ?::date', [filter.startDate]);
       }
     }
     if (filter.endDate) {
-      if (isSqlite) {
+      if (isSqlite()) {
         query = query.andWhereRaw('date(created_at) <= date(?)', [filter.endDate]);
       } else {
         query = query.andWhereRaw('(created_at)::date <= ?::date', [filter.endDate]);
@@ -171,7 +172,7 @@ class Order {
       .update({...params})
       .where('id', id)
       .returning('*');
-    return res[0];
+    return extractReturningRow<OrderRow>(res);
   }
 
   static async getWithID(id: number) {
@@ -182,9 +183,8 @@ class Order {
   }
 
   static async getDetailWithID(id: number) {
-    const isSqlite = (db as any).client.config.client === 'sqlite3';
-    const dateExpr = isSqlite ? 'date(orders.created_at)' : '(orders.created_at)::date';
-    const dateExprO2 = isSqlite ? 'date(o2.created_at)' : '(o2.created_at)::date';
+    const dateExpr = isSqlite() ? 'date(orders.created_at)' : '(orders.created_at)::date';
+    const dateExprO2 = isSqlite() ? 'date(o2.created_at)' : '(o2.created_at)::date';
 
     const order = await Table()
       .select(

--- a/src/server/models/receipts.js
+++ b/src/server/models/receipts.js
@@ -1,4 +1,5 @@
 const db = require('./db');
+const { extractInsertId } = require('../db/insert-id');
 
 const Table = () => db('receipts');
 
@@ -14,7 +15,7 @@ class Receipts {
         tax_cents : params.taxCents,
         total_cents : params.totalCents
       }).returning('id');
-    return res[0];
+    return extractInsertId(res);
   }
 
   static async getWithId(id){

--- a/src/server/models/whatsapp_message_log.ts
+++ b/src/server/models/whatsapp_message_log.ts
@@ -3,6 +3,7 @@ import type {
   WhatsAppLogInsertRow,
   WhatsAppMessageLogRow,
 } from '../../shared/whatsapp';
+import { extractInsertId } from '../db/insert-id';
 
 const Table = () => db('whatsapp_message_log');
 
@@ -21,7 +22,7 @@ class WhatsAppMessageLog {
     row: WhatsAppLogInsertRow
   ): Promise<WhatsAppMessageLogRow | null> {
     try {
-      const [id] = await Table().insert({
+      const result = await Table().insert({
         dedupe_key: row.dedupe_key,
         wa_message_id: row.wa_message_id ?? null,
         direction: row.direction,
@@ -31,8 +32,8 @@ class WhatsAppMessageLog {
         wa_id: row.wa_id ?? null,
         payload_json: row.payload_json,
       });
-      const pk = typeof id === 'object' && id !== null && 'id' in id ? (id as { id: number }).id : id;
-      return Table().where({ id: pk as number }).first();
+      const id = extractInsertId(result);
+      return Table().where({ id }).first();
     } catch (err) {
       if (isDuplicateKeyError(err)) {
         return null;

--- a/src/server/models/whatsapp_opt_ins.ts
+++ b/src/server/models/whatsapp_opt_ins.ts
@@ -1,11 +1,12 @@
 import db from './db';
 import type { WhatsAppOptInCreateParams, WhatsAppOptInRow } from '../../shared/whatsapp';
+import { extractInsertId } from '../db/insert-id';
 
 const Table = () => db('whatsapp_opt_ins');
 
 class WhatsAppOptIns {
   static async create(params: WhatsAppOptInCreateParams): Promise<WhatsAppOptInRow> {
-    const [id] = await Table().insert({
+    const result = await Table().insert({
       customer_id: params.customerId,
       merchant_id: params.merchantId,
       order_id: params.orderId ?? null,
@@ -14,8 +15,8 @@ class WhatsAppOptIns {
       opt_in_source: params.optInSource ?? 'web_checkout',
       marketing_allowed: params.marketingAllowed ?? false,
     });
-    const pk = typeof id === 'object' && id !== null && 'id' in id ? (id as { id: number }).id : id;
-    const row = await Table().where({ id: pk as number }).first();
+    const id = extractInsertId(result);
+    const row = await Table().where({ id }).first();
     return row as WhatsAppOptInRow;
   }
 

--- a/src/server/routes/index.js
+++ b/src/server/routes/index.js
@@ -2,7 +2,7 @@ var express = require('express');
 var router = express.Router();
 
 /* GET home page. */
-router.get('/*', function(req, res, next) {
+router.get('/{*splat}', function(req, res, next) {
   res.render('index', {
     currentUser: null,
     pageTitle: 'SequelCommerce Node.js Demo',

--- a/src/server/services/actions.ts
+++ b/src/server/services/actions.ts
@@ -145,11 +145,10 @@ export async function createOrder({ merchantId, customerName, customerPhone, ord
     throw new Error('At least one item is required');
   }
 
-  const customerIds = await Customers.create({
+  const customerId = await Customers.create({
     name: customerName,
     ...(customerPhone ? { mobile_phone: customerPhone } : {}),
   });
-  const customerId = customerIds[0];
 
   const orderUuid = await Orders.create({ merchantId: merchant.id, customerId, orderType });
   const { order } = await Orders.getByUuid(orderUuid);

--- a/src/server/services/checkout.ts
+++ b/src/server/services/checkout.ts
@@ -96,25 +96,15 @@ export async function submitMenuCheckout(
   const customerName =
     (body.contact?.name && body.contact.name.trim()) || 'Guest';
 
-  const customerIds = await Customers.create({
+  const customerId = await Customers.create({
     name: customerName,
     mobile_phone: phone,
     email,
   });
-  const firstId = Array.isArray(customerIds) ? customerIds[0] : customerIds;
-  const customerIdNum =
-    typeof firstId === 'number'
-      ? firstId
-      : typeof firstId === 'object' && firstId !== null && 'id' in firstId
-        ? Number((firstId as { id: number }).id)
-        : Number(firstId);
-  if (!customerIdNum || Number.isNaN(customerIdNum)) {
-    throw new CheckoutError(500, 'Failed to create customer');
-  }
 
   const orderUuid = await Orders.create({
     merchantId,
-    customerId: customerIdNum,
+    customerId,
     orderType,
   });
 
@@ -138,7 +128,7 @@ export async function submitMenuCheckout(
 
   if (whatsappOptIn && phone) {
     await WhatsAppOptIns.create({
-      customerId: customerIdNum,
+      customerId,
       merchantId,
       orderId: order.id,
       phoneE164: phone,
@@ -161,7 +151,7 @@ export async function submitMenuCheckout(
 
   return {
     orderUuid,
-    receiptId: typeof receiptId === 'object' ? Number((receiptId as { id: number }).id) : Number(receiptId),
+    receiptId,
     displayTotalCents: totals.totalCents,
   };
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**PR 1 of 2** for the Knex upgrade. Normalizes insert/returning result handling while staying on **Knex 0.20** — safe to merge before bumping Knex to 3.x.

## New utilities

- `src/server/db/insert-id.ts` — `extractInsertId()` and `extractReturningRow()` handle both Knex 0.20 shapes (`[42]`) and Knex 1+ shapes (`[{ id: 42 }]`)
- `src/server/db/dialect.ts` — `isSqlite()` via `DB_CLIENT` (replaces fragile `db.client.config` access in `orders.ts`)

## Model refactors

| Model | Change |
|-------|--------|
| `customers.ts` | `create()` returns `Promise<number>` |
| `merchants.ts` | `create()` / `update()` return `number` |
| `lineItems.js`, `receipts.js` | Use `extractInsertId` |
| `menu_categories.ts`, `whatsapp_*` | Use `extractInsertId` |
| `menu_items.js`, `modifiers.js` | Use `extractReturningRow` |
| `orders.ts` | Use `isSqlite()` + `extractReturningRow` on update |

## Service layer

- `actions.ts` — simplified customer ID after create
- `checkout.ts` — removed inline Knex shape branching

## Also included

- **Wildcard routes** `/*` → `/{*splat}` (fixes `path-to-regexp` v8 error when e2e loads Express app)
- **Test teardown** FK order for `whatsapp_opt_ins` / `receipts`
- **e2e spec** — `createRequire` for CJS app/db imports under Mocha ESM
- **6 unit tests** for insert-id helpers
- `mocha --exit` on `pnpm test`

## Verification

- `pnpm test` — **66 passing** (60 existing + 6 new)

## Next step (PR 2)

Bump `knex` to `^3.2.x` and update `knexfile.js` — code should already handle RETURNING shape changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8220adce-0298-45fb-9b9a-c418a9ca4cbe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8220adce-0298-45fb-9b9a-c418a9ca4cbe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

