### PR TITLE
Adopt Shopify Polaris for merchant CRUD admin views

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "node": ">=22.14.0"
   },
   "dependencies": {
+    "@shopify/polaris": "^10.50.1",
     "camelcase-keys": "^6.2.2",
     "chai": "^4.5.0",
     "cookie-parser": "~1.4.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@shopify/polaris':
+        specifier: ^10.50.1
+        version: 10.50.1(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
       camelcase-keys:
         specifier: ^6.2.2
         version: 6.2.2
@@ -764,6 +767,18 @@ packages:
     resolution: {integrity: sha512-tkuFxhvKO/HlGd0VsINF6vHSYH8AF8W0TcNxKDK6JZmrehngFj78pToc8iemtnvwilDjs2G/qSzYFhe9U8q+fw==}
     cpu: [x64]
     os: [win32]
+
+  '@shopify/polaris-icons@6.16.0':
+    resolution: {integrity: sha512-vEF/6yVSvgPTBgWDbpmcPsZvTyKu+2BeuTYo7Ys6vDTY8ZSQSpK+/uhdT3CJ0WSTr4yibnXeWP6eqssqBmJWtg==}
+
+  '@shopify/polaris-tokens@6.14.0':
+    resolution: {integrity: sha512-eMa9X0QzOB3o/4O1ATcPKpc4NPqm57lpaqiRkRu8XRkKzwH+kL9J6vI8YNnDbePfndMNAA9MRp0HR1XqaPxCMg==}
+
+  '@shopify/polaris@10.50.1':
+    resolution: {integrity: sha512-7wd79OG0UGbBzWQyGJ4OgaEkN9TTLHmnNKFxw3WJmSGxNiVHOkChjiN6VaH0Gvlp0mWRvKsTTK4T4zML2esHJA==}
+    peerDependencies:
+      react: ^16.14.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.14.0 || ^17.0.0 || ^18.0.0
 
   '@tailwindcss/node@4.3.0':
     resolution: {integrity: sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==}
@@ -2295,6 +2310,9 @@ packages:
     peerDependencies:
       react: ^16.14.0
 
+  react-fast-compare@3.2.2:
+    resolution: {integrity: sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==}
+
   react-i18next@16.6.6:
     resolution: {integrity: sha512-ZgL2HUoW34UKUkOV7uSQFE1CDnRPD+tCR3ywSuWH7u2iapnz86U8Bi3Vrs620qNDzCf1F47NxglCEkchCTDOHw==}
     peerDependencies:
@@ -3219,6 +3237,22 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.61.0':
     optional: true
+
+  '@shopify/polaris-icons@6.16.0': {}
+
+  '@shopify/polaris-tokens@6.14.0': {}
+
+  '@shopify/polaris@10.50.1(react-dom@16.14.0(react@16.14.0))(react@16.14.0)':
+    dependencies:
+      '@shopify/polaris-icons': 6.16.0
+      '@shopify/polaris-tokens': 6.14.0
+      '@types/react': 19.2.16
+      '@types/react-dom': 19.2.3(@types/react@19.2.16)
+      '@types/react-transition-group': 4.4.12(@types/react@19.2.16)
+      react: 16.14.0
+      react-dom: 16.14.0(react@16.14.0)
+      react-fast-compare: 3.2.2
+      react-transition-group: 4.4.5(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
 
   '@tailwindcss/node@4.3.0':
     dependencies:
@@ -4840,6 +4874,8 @@ snapshots:
       prop-types: 15.8.1
       react: 16.14.0
       scheduler: 0.19.1
+
+  react-fast-compare@3.2.2: {}
 
   react-i18next@16.6.6(i18next@25.10.10(typescript@5.9.3))(react-dom@16.14.0(react@16.14.0))(react@16.14.0)(typescript@5.9.3):
     dependencies:

--- a/src/client/js/components/MerchantAdminLayout.tsx
+++ b/src/client/js/components/MerchantAdminLayout.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { Page } from '@shopify/polaris';
+import type { MenuActionDescriptor, PageProps } from '@shopify/polaris';
+import LangSwitcher from './LangSwitcher';
+import MerchantPolarisProvider from './MerchantPolarisProvider';
+
+interface MerchantAdminLayoutProps {
+  merchantUuid: string;
+  title: string;
+  onBack: () => void;
+  backLabel: string;
+  primaryAction?: PageProps['primaryAction'];
+  secondaryActions?: MenuActionDescriptor[];
+  children: React.ReactNode;
+  showNav?: boolean;
+}
+
+export default function MerchantAdminLayout({
+  merchantUuid,
+  title,
+  onBack,
+  backLabel,
+  primaryAction,
+  secondaryActions = [],
+  children,
+  showNav = true,
+}: MerchantAdminLayoutProps) {
+  const navActions = showNav
+    ? [
+        { content: 'Menus', url: `/merchant-dashboard/${merchantUuid}/online-menus` },
+        { content: 'Menu Items', url: `/merchant-dashboard/${merchantUuid}/menuitems` },
+        { content: 'Settings', url: `/merchant-dashboard/${merchantUuid}/settings` },
+      ]
+    : [];
+
+  return (
+    <MerchantPolarisProvider>
+      <Page
+        title={title}
+        titleMetadata={<LangSwitcher />}
+        backAction={{ content: backLabel, onAction: onBack }}
+        primaryAction={primaryAction}
+        secondaryActions={[...navActions, ...(secondaryActions || [])]}
+      >
+        {children}
+      </Page>
+    </MerchantPolarisProvider>
+  );
+}

--- a/src/client/js/components/MerchantPolarisProvider.tsx
+++ b/src/client/js/components/MerchantPolarisProvider.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { AppProvider } from '@shopify/polaris';
+import enTranslations from '@shopify/polaris/locales/en.json';
+import '@shopify/polaris/build/esm/styles.css';
+
+interface MerchantPolarisProviderProps {
+  children: React.ReactNode;
+}
+
+export default function MerchantPolarisProvider({ children }: MerchantPolarisProviderProps) {
+  return <AppProvider i18n={enTranslations}>{children}</AppProvider>;
+}

--- a/src/client/js/lib/merchantApi.ts
+++ b/src/client/js/lib/merchantApi.ts
@@ -1,0 +1,50 @@
+export function fetchApi(url: string) {
+  return fetch(url, { credentials: 'same-origin' as const }).then((r) => r.json());
+}
+
+export function postApi(url: string, body: unknown) {
+  return fetch(url, {
+    method: 'POST',
+    credentials: 'same-origin' as const,
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    body: JSON.stringify(body),
+  }).then(async (r) => {
+    const data = await r.json().catch(() => ({}));
+    if (!r.ok) throw new Error((data as { error?: string })?.error || 'Request failed');
+    return data;
+  });
+}
+
+export function putApi(url: string, body: unknown) {
+  return fetch(url, {
+    method: 'PUT',
+    credentials: 'same-origin' as const,
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    body: JSON.stringify(body),
+  }).then(async (r) => {
+    const data = await r.json().catch(() => ({}));
+    if (!r.ok) throw new Error((data as { error?: string })?.error || 'Request failed');
+    return data;
+  });
+}
+
+export function patchApi(url: string, body: unknown) {
+  return fetch(url, {
+    method: 'PATCH',
+    credentials: 'same-origin' as const,
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    body: JSON.stringify(body),
+  }).then(async (r) => {
+    const data = await r.json().catch(() => ({}));
+    if (!r.ok) throw new Error((data as { error?: string })?.error || 'Request failed');
+    return data;
+  });
+}
+
+export function deleteApi(url: string) {
+  return fetch(url, {
+    method: 'DELETE',
+    credentials: 'same-origin' as const,
+    headers: { Accept: 'application/json' },
+  });
+}

--- a/src/client/js/pages/MerchantMenuItems.tsx
+++ b/src/client/js/pages/MerchantMenuItems.tsx
@@ -1,49 +1,27 @@
 import React, { useEffect, useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import LangSwitcher from '../components/LangSwitcher';
-import type { MerchantRow, MerchantTheme } from '../../../shared/merchants';
-import { resolveMerchantTheme } from '../../../shared/merchants';
-import '../../css/pages/MerchantMenuItems.css';
-
-function fetchApi(url: string) {
-  return fetch(url, { credentials: 'same-origin' as const }).then((r) => r.json());
-}
-
-function postApi(url: string, body: any) {
-  return fetch(url, {
-    method: 'POST',
-    credentials: 'same-origin' as const,
-    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
-    body: JSON.stringify(body),
-  }).then(async (r) => {
-    const data = await r.json().catch(() => ({}));
-    if (!r.ok) throw new Error((data as any)?.error || 'Request failed');
-    return data;
-  });
-}
-
-function putApi(url: string, body: any) {
-  return fetch(url, {
-    method: 'PUT',
-    credentials: 'same-origin' as const,
-    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
-    body: JSON.stringify(body),
-  }).then(async (r) => {
-    const data = await r.json().catch(() => ({}));
-    if (!r.ok) throw new Error((data as any)?.error || 'Request failed');
-    return data;
-  });
-}
-
-function deleteApi(url: string) {
-  return fetch(url, {
-    method: 'DELETE',
-    credentials: 'same-origin' as const,
-    headers: { Accept: 'application/json' },
-  });
-}
-
-// ─── Main Container ───
+import {
+  Banner,
+  Button,
+  Card,
+  Checkbox,
+  ChoiceList,
+  EmptyState,
+  Form,
+  FormLayout,
+  IndexTable,
+  Layout,
+  Modal,
+  Page,
+  ResourceList,
+  Spinner,
+  Text,
+  TextField,
+} from '@shopify/polaris';
+import type { MerchantRow } from '../../../shared/merchants';
+import MerchantAdminLayout from '../components/MerchantAdminLayout';
+import MerchantPolarisProvider from '../components/MerchantPolarisProvider';
+import { deleteApi, fetchApi, postApi, putApi } from '../lib/merchantApi';
 
 export default function MerchantMenuItems(props: any) {
   const { t } = useTranslation();
@@ -70,17 +48,21 @@ export default function MerchantMenuItems(props: any) {
 
   if (error) {
     return (
-      <div className="MerchantMenuItems MerchantMenuItems--error">
-        <div className="MerchantMenuItems__error">{error}</div>
-      </div>
+      <MerchantPolarisProvider>
+        <Page title={t('merchant.menuItems')}>
+          <Banner status="critical">{error}</Banner>
+        </Page>
+      </MerchantPolarisProvider>
     );
   }
 
   if (!merchant) {
     return (
-      <div className="MerchantMenuItems">
-        <div className="MerchantMenuItems__loading">{t('common.loading')}</div>
-      </div>
+      <MerchantPolarisProvider>
+        <Page title={t('merchant.menuItems')}>
+          <Spinner accessibilityLabel={t('common.loading')} size="large" />
+        </Page>
+      </MerchantPolarisProvider>
     );
   }
 
@@ -88,6 +70,7 @@ export default function MerchantMenuItems(props: any) {
     return (
       <MenuItemForm
         merchant={merchant}
+        merchantUuid={merchantUuid}
         onBack={() => props.history.push(`/merchant-dashboard/${merchantUuid}/menuitems`)}
         onSuccess={() => props.history.push(`/merchant-dashboard/${merchantUuid}/menuitems`)}
         t={t}
@@ -99,6 +82,7 @@ export default function MerchantMenuItems(props: any) {
     return (
       <MenuItemForm
         merchant={merchant}
+        merchantUuid={merchantUuid}
         menuItemId={parseInt(menuItemId, 10)}
         onBack={() => props.history.push(`/merchant-dashboard/${merchantUuid}/menuitems`)}
         onSuccess={() => props.history.push(`/merchant-dashboard/${merchantUuid}/menuitems`)}
@@ -119,8 +103,6 @@ export default function MerchantMenuItems(props: any) {
   );
 }
 
-// ─── Menu Items List ───
-
 function MenuItemsList({
   merchant,
   merchantUuid,
@@ -139,6 +121,7 @@ function MenuItemsList({
   const [menuItems, setMenuItems] = useState<any[]>([]);
   const [modifiers, setModifiers] = useState<any[]>([]);
   const [showModifiersModal, setShowModifiersModal] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
 
   const loadMenuItems = useCallback(() => {
     fetchApi(`/api/merchants/${merchant.id}/menu-items`).then((data) =>
@@ -157,16 +140,11 @@ function MenuItemsList({
     loadModifiers();
   }, [loadMenuItems, loadModifiers]);
 
-  const [deleteError, setDeleteError] = useState<string | null>(null);
-
-  const theme = resolveMerchantTheme(merchant.theme);
-
   const handleDelete = async (id: number) => {
     if (!confirm(t('merchant.deleteMenuItemConfirm'))) return;
     setDeleteError(null);
     const res = await deleteApi(`/api/merchants/${merchant.id}/menu-items/${id}`);
     if (res.ok) {
-      setDeleteError(null);
       loadMenuItems();
     } else {
       const data = await res.json().catch(() => ({}));
@@ -174,95 +152,82 @@ function MenuItemsList({
     }
   };
 
+  const rowMarkup = menuItems.map((item: any, index: number) => (
+    <IndexTable.Row id={String(item.id)} key={item.id} position={index}>
+      <IndexTable.Cell>
+        <Text variant="bodyMd" fontWeight="semibold" as="span">
+          {item.name}
+        </Text>
+      </IndexTable.Cell>
+      <IndexTable.Cell>
+        {(item.description || '').slice(0, 50)}
+        {(item.description || '').length > 50 ? '…' : ''}
+      </IndexTable.Cell>
+      <IndexTable.Cell>${((item.price_cents || 0) / 100).toFixed(2)}</IndexTable.Cell>
+      <IndexTable.Cell>
+        {item.modifiers?.length ? item.modifiers.map((m: any) => m.name).join(', ') : '—'}
+      </IndexTable.Cell>
+      <IndexTable.Cell>{item.is_active !== false ? t('common.yes') : t('common.no')}</IndexTable.Cell>
+      <IndexTable.Cell>
+        <Button plain onClick={() => history.push(`/merchant-dashboard/${merchantUuid}/menuitems/${item.id}/edit`)}>
+          {t('common.edit')}
+        </Button>
+        {' · '}
+        <Button plain destructive onClick={() => handleDelete(item.id)}>
+          {t('common.delete')}
+        </Button>
+      </IndexTable.Cell>
+    </IndexTable.Row>
+  ));
+
   return (
-    <div className={`MerchantMenuItems MerchantMenuItems--theme-${theme}`}>
-      <header className="MerchantMenuItems__header">
-        <button type="button" className="MerchantMenuItems__back" onClick={onBack}>
-          {t('merchant.backToOrders')}
-        </button>
-        <h1 className="MerchantMenuItems__title">{merchant.business_name} — {t('merchant.menuItems')} <LangSwitcher /></h1>
-        <div className="MerchantMenuItems__actions">
-          <a href={`/merchant-dashboard/${merchantUuid}/settings`} className="MerchantMenuItems__link MerchantMenuItems__link--nav">
-            {t('merchant.settings')}
-          </a>
-          <button
-            type="button"
-            className="MerchantMenuItems__btn MerchantMenuItems__btn--secondary"
-            onClick={() => setShowModifiersModal(true)}
-          >
-            {t('merchant.manageModifiers')}
-          </button>
-          <button
-            type="button"
-            className="MerchantMenuItems__btn MerchantMenuItems__btn--primary"
-            onClick={onAddClick}
-          >
-            {t('merchant.addMenuItem')}
-          </button>
-        </div>
-      </header>
-
-      {deleteError && (
-        <div className="MerchantMenuItems__error" style={{ marginBottom: 16 }}>
-          {deleteError}
-        </div>
-      )}
-
-      <div className="MerchantMenuItems__list">
-        {menuItems.length === 0 ? (
-          <div className="MerchantMenuItems__empty">
-            {t('merchant.noMenuItems')} <button onClick={onAddClick}>{t('merchant.addFirstItem')}</button>
-          </div>
-        ) : (
-          <table className="MerchantMenuItems__table">
-            <thead>
-              <tr>
-                <th>{t('common.name')}</th>
-                <th>{t('common.description')}</th>
-                <th>{t('common.price')}</th>
-                <th>{t('merchant.modifiers')}</th>
-                <th>{t('merchant.active')}</th>
-                <th></th>
-              </tr>
-            </thead>
-            <tbody>
-              {menuItems.map((item: any) => (
-                <tr key={item.id}>
-                  <td className="MerchantMenuItems__cell-name">{item.name}</td>
-                  <td className="MerchantMenuItems__cell-desc">
-                    {(item.description || '').slice(0, 50)}
-                    {(item.description || '').length > 50 ? '…' : ''}
-                  </td>
-                  <td>${((item.price_cents || 0) / 100).toFixed(2)}</td>
-                  <td>
-                    {item.modifiers?.length
-                      ? item.modifiers.map((m: any) => m.name).join(', ')
-                      : '—'}
-                  </td>
-                  <td>{item.is_active !== false ? t('common.yes') : t('common.no')}</td>
-                  <td>
-                    <button
-                      type="button"
-                      className="MerchantMenuItems__link"
-                      onClick={() => history.push(`/merchant-dashboard/${merchantUuid}/menuitems/${item.id}/edit`)}
-                    >
-                      {t('common.edit')}
-                    </button>
-                    {' · '}
-                    <button
-                      type="button"
-                      className="MerchantMenuItems__link MerchantMenuItems__link--danger"
-                      onClick={() => handleDelete(item.id)}
-                    >
-                      {t('common.delete')}
-                    </button>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+    <MerchantAdminLayout
+      merchantUuid={merchantUuid}
+      title={`${merchant.business_name} — ${t('merchant.menuItems')}`}
+      backLabel={t('merchant.backToOrders')}
+      onBack={onBack}
+      primaryAction={{ content: t('merchant.addMenuItem'), onAction: onAddClick }}
+      secondaryActions={[{ content: t('merchant.manageModifiers'), onAction: () => setShowModifiersModal(true) }]}
+    >
+      <Layout>
+        {deleteError && (
+          <Layout.Section>
+            <Banner status="critical" onDismiss={() => setDeleteError(null)}>
+              {deleteError}
+            </Banner>
+          </Layout.Section>
         )}
-      </div>
+
+        <Layout.Section>
+          {menuItems.length === 0 ? (
+            <Card sectioned>
+              <EmptyState
+                heading={t('merchant.noMenuItems')}
+                action={{ content: t('merchant.addFirstItem'), onAction: onAddClick }}
+                image="https://cdn.shopify.com/s/files/1/0262/4071/2726/files/emptystate-files.png"
+              />
+            </Card>
+          ) : (
+            <Card>
+              <IndexTable
+                resourceName={{ singular: 'menu item', plural: 'menu items' }}
+                itemCount={menuItems.length}
+                headings={[
+                  { title: t('common.name') },
+                  { title: t('common.description') },
+                  { title: t('common.price') },
+                  { title: t('merchant.modifiers') },
+                  { title: t('merchant.active') },
+                  { title: '' },
+                ]}
+                selectable={false}
+              >
+                {rowMarkup}
+              </IndexTable>
+            </Card>
+          )}
+        </Layout.Section>
+      </Layout>
 
       {showModifiersModal && (
         <ModifiersModal
@@ -276,11 +241,9 @@ function MenuItemsList({
           t={t}
         />
       )}
-    </div>
+    </MerchantAdminLayout>
   );
 }
-
-// ─── Modifiers Modal ───
 
 function ModifiersModal({
   merchant,
@@ -296,21 +259,21 @@ function ModifiersModal({
   t: (key: string) => string;
 }) {
   const [name, setName] = useState('');
-  const [priceAdjustmentCents, setPriceAdjustmentCents] = useState(0);
+  const [priceAdjustmentCents, setPriceAdjustmentCents] = useState('0');
   const [saving, setSaving] = useState(false);
   const [editingId, setEditingId] = useState<number | null>(null);
   const [editName, setEditName] = useState('');
-  const [editPrice, setEditPrice] = useState(0);
+  const [editPrice, setEditPrice] = useState('0');
 
   const handleCreate = async () => {
     if (!name.trim()) return;
     setSaving(true);
     await postApi(`/api/merchants/${merchant.id}/modifiers`, {
       name: name.trim(),
-      priceAdjustmentCents,
+      priceAdjustmentCents: parseInt(priceAdjustmentCents, 10) || 0,
     });
     setName('');
-    setPriceAdjustmentCents(0);
+    setPriceAdjustmentCents('0');
     setSaving(false);
     onSaved();
   };
@@ -319,7 +282,7 @@ function ModifiersModal({
     setSaving(true);
     await putApi(`/api/merchants/${merchant.id}/modifiers/${id}`, {
       name: editName.trim(),
-      priceAdjustmentCents: editPrice,
+      priceAdjustmentCents: parseInt(editPrice, 10) || 0,
     });
     setEditingId(null);
     setSaving(false);
@@ -335,129 +298,124 @@ function ModifiersModal({
   const startEdit = (m: any) => {
     setEditingId(m.id);
     setEditName(m.name);
-    setEditPrice(m.price_adjustment_cents || 0);
+    setEditPrice(String(m.price_adjustment_cents || 0));
   };
 
   return (
-    <div className="ModifiersModal__overlay" onClick={onClose}>
-      <div className="ModifiersModal" onClick={(e) => e.stopPropagation()}>
-        <h2>{t('merchant.modifiersTitle')}</h2>
-        <p className="ModifiersModal__hint">
+    <Modal
+      open
+      onClose={onClose}
+      title={t('merchant.modifiersTitle')}
+      primaryAction={{ content: t('common.close'), onAction: onClose }}
+    >
+      <Modal.Section>
+        <Text as="p" variant="bodyMd" color="subdued">
           {t('merchant.modifiersHintModal')}
-        </p>
+        </Text>
+      </Modal.Section>
 
-        <div className="ModifiersModal__add">
-          <input
-            type="text"
-            placeholder={t('merchant.modifierNamePlaceholder')}
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            className="ModifiersModal__input"
-          />
-          <input
-            type="number"
-            placeholder={t('merchant.priceAddPlaceholder')}
-            value={priceAdjustmentCents || ''}
-            onChange={(e) => setPriceAdjustmentCents(parseInt(e.target.value, 10) || 0)}
-            className="ModifiersModal__input ModifiersModal__input--narrow"
-          />
-          <button
-            type="button"
-            className="MerchantMenuItems__btn MerchantMenuItems__btn--primary"
-            onClick={handleCreate}
-            disabled={saving || !name.trim()}
-          >
+      <Modal.Section>
+        <FormLayout>
+          <FormLayout.Group>
+            <TextField
+              label={t('common.name')}
+              value={name}
+              onChange={setName}
+              autoComplete="off"
+              placeholder={t('merchant.modifierNamePlaceholder')}
+            />
+            <TextField
+              label={t('merchant.priceAddPlaceholder')}
+              value={priceAdjustmentCents}
+              onChange={setPriceAdjustmentCents}
+              type="number"
+              autoComplete="off"
+            />
+          </FormLayout.Group>
+          <Button primary onClick={handleCreate} disabled={saving || !name.trim()} loading={saving}>
             {t('merchant.addModifier')}
-          </button>
-        </div>
+          </Button>
+        </FormLayout>
+      </Modal.Section>
 
-        <ul className="ModifiersModal__list">
-          {modifiers.map((m) => (
-            <li key={m.id} className="ModifiersModal__item">
-              {editingId === m.id ? (
-                <>
-                  <input
-                    type="text"
-                    value={editName}
-                    onChange={(e) => setEditName(e.target.value)}
-                    className="ModifiersModal__input"
-                  />
-                  <input
-                    type="number"
-                    value={editPrice}
-                    onChange={(e) => setEditPrice(parseInt(e.target.value, 10) || 0)}
-                    className="ModifiersModal__input ModifiersModal__input--narrow"
-                  />
-                  <button
-                    type="button"
-                    className="MerchantMenuItems__btn MerchantMenuItems__btn--primary"
-                    onClick={() => handleUpdate(m.id)}
-                    disabled={saving}
-                  >
-                    {t('common.save')}
-                  </button>
-                  <button
-                    type="button"
-                    className="MerchantMenuItems__btn MerchantMenuItems__btn--secondary"
-                    onClick={() => setEditingId(null)}
-                  >
-                    {t('common.cancel')}
-                  </button>
-                </>
-              ) : (
-                <>
-                  <span className="ModifiersModal__item-name">{m.name}</span>
-                  <span className="ModifiersModal__item-price">
-                    {m.price_adjustment_cents
-                      ? `+$${(m.price_adjustment_cents / 100).toFixed(2)}`
-                      : t('merchant.noCharge')}
-                  </span>
-                  <button
-                    type="button"
-                    className="MerchantMenuItems__link"
-                    onClick={() => startEdit(m)}
-                  >
-                    {t('common.edit')}
-                  </button>
-                  <button
-                    type="button"
-                    className="MerchantMenuItems__link MerchantMenuItems__link--danger"
-                    onClick={() => handleDelete(m.id)}
-                  >
-                    {t('common.delete')}
-                  </button>
-                </>
-              )}
-            </li>
-          ))}
-        </ul>
-
-        {modifiers.length === 0 && (
-          <p className="ModifiersModal__empty">{t('merchant.noModifiersYet')}</p>
+      <Modal.Section>
+        {modifiers.length === 0 ? (
+          <Text as="p" color="subdued">
+            {t('merchant.noModifiersYet')}
+          </Text>
+        ) : (
+          <ResourceList
+            resourceName={{ singular: 'modifier', plural: 'modifiers' }}
+            items={modifiers}
+            renderItem={(m) => {
+              const isEditing = editingId === m.id;
+              return (
+                <ResourceList.Item
+                  id={String(m.id)}
+                  accessibilityLabel={m.name}
+                  onClick={() => {}}
+                >
+                  {isEditing ? (
+                    <FormLayout>
+                      <FormLayout.Group>
+                        <TextField label={t('common.name')} value={editName} onChange={setEditName} autoComplete="off" />
+                        <TextField
+                          label={t('merchant.priceAddPlaceholder')}
+                          value={editPrice}
+                          onChange={setEditPrice}
+                          type="number"
+                          autoComplete="off"
+                        />
+                      </FormLayout.Group>
+                      <FormLayout.Group>
+                        <Button primary onClick={() => handleUpdate(m.id)} disabled={saving} loading={saving}>
+                          {t('common.save')}
+                        </Button>
+                        <Button onClick={() => setEditingId(null)}>{t('common.cancel')}</Button>
+                      </FormLayout.Group>
+                    </FormLayout>
+                  ) : (
+                    <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12 }}>
+                      <div>
+                        <Text as="span" variant="bodyMd" fontWeight="semibold">
+                          {m.name}
+                        </Text>
+                        <Text as="p" variant="bodySm" color="subdued">
+                          {m.price_adjustment_cents
+                            ? `+$${(m.price_adjustment_cents / 100).toFixed(2)}`
+                            : t('merchant.noCharge')}
+                        </Text>
+                      </div>
+                      <div>
+                        <Button plain onClick={() => startEdit(m)}>
+                          {t('common.edit')}
+                        </Button>
+                        <Button plain destructive onClick={() => handleDelete(m.id)}>
+                          {t('common.delete')}
+                        </Button>
+                      </div>
+                    </div>
+                  )}
+                </ResourceList.Item>
+              );
+            }}
+          />
         )}
-
-        <button
-          type="button"
-          className="MerchantMenuItems__btn MerchantMenuItems__btn--secondary"
-          onClick={onClose}
-        >
-          {t('common.close')}
-        </button>
-      </div>
-    </div>
+      </Modal.Section>
+    </Modal>
   );
 }
 
-// ─── Menu Item Form (Add / Edit) ───
-
 function MenuItemForm({
   merchant,
+  merchantUuid,
   menuItemId,
   onBack,
   onSuccess,
   t,
 }: {
   merchant: MerchantRow;
+  merchantUuid: string;
   menuItemId?: number;
   onBack: () => void;
   onSuccess: () => void;
@@ -468,7 +426,7 @@ function MenuItemForm({
   const [description, setDescription] = useState('');
   const [priceCents, setPriceCents] = useState('');
   const [isActive, setIsActive] = useState(true);
-  const [selectedModifierIds, setSelectedModifierIds] = useState<number[]>([]);
+  const [selectedModifierIds, setSelectedModifierIds] = useState<string[]>([]);
   const [modifiers, setModifiers] = useState<any[]>([]);
   const [loading, setLoading] = useState(isEdit);
   const [saving, setSaving] = useState(false);
@@ -490,7 +448,7 @@ function MenuItemForm({
             setDescription(item.description || '');
             setPriceCents(String(item.price_cents || ''));
             setIsActive(item.is_active !== false);
-            setSelectedModifierIds((item.modifiers || []).map((m: any) => m.id));
+            setSelectedModifierIds((item.modifiers || []).map((m: any) => String(m.id)));
           }
         })
         .catch(() => setError(t('merchant.loadMenuItemFailed')))
@@ -498,14 +456,7 @@ function MenuItemForm({
     }
   }, [isEdit, menuItemId, merchant.id, t]);
 
-  const toggleModifier = (id: number) => {
-    setSelectedModifierIds((prev) =>
-      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]
-    );
-  };
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
+  const handleSubmit = async () => {
     const price = parseInt(priceCents, 10);
     if (!name.trim() || isNaN(price) || price < 0) {
       setError(t('merchant.namePriceRequired'));
@@ -513,146 +464,112 @@ function MenuItemForm({
     }
     setSaving(true);
     setError(null);
+    const modifierIds = selectedModifierIds.map((id) => parseInt(id, 10));
     try {
+      const payload = {
+        name: name.trim(),
+        description: description.trim(),
+        priceCents: price,
+        isActive,
+        modifierIds,
+      };
       if (isEdit && menuItemId) {
-        await putApi(`/api/merchants/${merchant.id}/menu-items/${menuItemId}`, {
-          name: name.trim(),
-          description: description.trim(),
-          priceCents: price,
-          isActive,
-          modifierIds: selectedModifierIds,
-        });
+        await putApi(`/api/merchants/${merchant.id}/menu-items/${menuItemId}`, payload);
       } else {
-        await postApi(`/api/merchants/${merchant.id}/menu-items`, {
-          name: name.trim(),
-          description: description.trim(),
-          priceCents: price,
-          isActive,
-          modifierIds: selectedModifierIds,
-        });
+        await postApi(`/api/merchants/${merchant.id}/menu-items`, payload);
       }
       onSuccess();
-    } catch (err) {
+    } catch {
       setError(t('merchant.saveFailed'));
     } finally {
       setSaving(false);
     }
   };
 
-  const theme = resolveMerchantTheme(merchant.theme);
-
   if (loading) {
     return (
-      <div className={`MerchantMenuItems MerchantMenuItems--theme-${theme}`}>
-        <div className="MerchantMenuItems__loading">{t('common.loading')}</div>
-      </div>
+      <MerchantPolarisProvider>
+        <Page title={isEdit ? t('merchant.editMenuItem') : t('merchant.addMenuItemTitle')}>
+          <Spinner accessibilityLabel={t('common.loading')} size="large" />
+        </Page>
+      </MerchantPolarisProvider>
     );
   }
 
+  const modifierChoices = modifiers.map((m) => ({
+    label: `${m.name}${m.price_adjustment_cents ? ` (+$${(m.price_adjustment_cents / 100).toFixed(2)})` : ''}`,
+    value: String(m.id),
+  }));
+
   return (
-    <div className={`MerchantMenuItems MerchantMenuItems--theme-${theme}`}>
-      <header className="MerchantMenuItems__header">
-        <button type="button" className="MerchantMenuItems__back" onClick={onBack}>
-          {t('merchant.backToMenuItems')}
-        </button>
-        <h1 className="MerchantMenuItems__title">
-          {isEdit ? t('merchant.editMenuItem') : t('merchant.addMenuItemTitle')}
-        </h1>
-      </header>
+    <MerchantAdminLayout
+      merchantUuid={merchantUuid}
+      title={isEdit ? t('merchant.editMenuItem') : t('merchant.addMenuItemTitle')}
+      backLabel={t('merchant.backToMenuItems')}
+      onBack={onBack}
+      showNav={false}
+    >
+      <Layout>
+        {error && (
+          <Layout.Section>
+            <Banner status="critical" onDismiss={() => setError(null)}>
+              {error}
+            </Banner>
+          </Layout.Section>
+        )}
 
-      <form className="MerchantMenuItems__form" onSubmit={handleSubmit}>
-        {error && <div className="MerchantMenuItems__error">{error}</div>}
-
-        <div className="MerchantMenuItems__field">
-          <label htmlFor="name">{t('merchant.nameRequired')}</label>
-          <input
-            id="name"
-            type="text"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            required
-            className="MerchantMenuItems__input"
-          />
-        </div>
-
-        <div className="MerchantMenuItems__field">
-          <label htmlFor="description">{t('common.description')}</label>
-          <textarea
-            id="description"
-            value={description}
-            onChange={(e) => setDescription(e.target.value)}
-            className="MerchantMenuItems__input MerchantMenuItems__textarea"
-            rows={3}
-          />
-        </div>
-
-        <div className="MerchantMenuItems__field">
-          <label htmlFor="price">{t('merchant.priceCents')}</label>
-          <input
-            id="price"
-            type="number"
-            min="0"
-            value={priceCents}
-            onChange={(e) => setPriceCents(e.target.value)}
-            required
-            className="MerchantMenuItems__input"
-          />
-          <span className="MerchantMenuItems__hint">{t('merchant.priceHint')}</span>
-        </div>
-
-        <div className="MerchantMenuItems__field">
-          <label>
-            <input
-              type="checkbox"
-              checked={isActive}
-              onChange={(e) => setIsActive(e.target.checked)}
-            />
-            {' '}{t('merchant.activeLabel')}
-          </label>
-        </div>
-
-        <div className="MerchantMenuItems__field">
-          <label>{t('merchant.modifiers')}</label>
-          <p className="MerchantMenuItems__hint">
-            {t('merchant.modifiersHint')}
-          </p>
-          {modifiers.length === 0 ? (
-            <p className="MerchantMenuItems__hint">
-              {t('merchant.noModifiersHint')}
-            </p>
-          ) : (
-            <div className="MerchantMenuItems__modifiers">
-              {modifiers.map((m) => (
-                <label key={m.id} className="MerchantMenuItems__modifier-label">
-                  <input
-                    type="checkbox"
-                    checked={selectedModifierIds.includes(m.id)}
-                    onChange={() => toggleModifier(m.id)}
+        <Layout.Section>
+          <Card sectioned>
+            <Form onSubmit={handleSubmit}>
+              <FormLayout>
+                <TextField
+                  label={t('merchant.nameRequired')}
+                  value={name}
+                  onChange={setName}
+                  autoComplete="off"
+                  requiredIndicator
+                />
+                <TextField
+                  label={t('common.description')}
+                  value={description}
+                  onChange={setDescription}
+                  multiline={3}
+                  autoComplete="off"
+                />
+                <TextField
+                  label={t('merchant.priceCents')}
+                  value={priceCents}
+                  onChange={setPriceCents}
+                  type="number"
+                  autoComplete="off"
+                  helpText={t('merchant.priceHint')}
+                  requiredIndicator
+                />
+                <Checkbox label={t('merchant.activeLabel')} checked={isActive} onChange={setIsActive} />
+                {modifiers.length === 0 ? (
+                  <Text as="p" color="subdued">
+                    {t('merchant.noModifiersHint')}
+                  </Text>
+                ) : (
+                  <ChoiceList
+                    title={t('merchant.modifiers')}
+                    allowMultiple
+                    choices={modifierChoices}
+                    selected={selectedModifierIds}
+                    onChange={setSelectedModifierIds}
                   />
-                  {' '}
-                  {m.name}
-                  {m.price_adjustment_cents
-                    ? ` (+$${(m.price_adjustment_cents / 100).toFixed(2)})`
-                    : ''}
-                </label>
-              ))}
-            </div>
-          )}
-        </div>
-
-        <div className="MerchantMenuItems__form-actions">
-          <button type="button" className="MerchantMenuItems__btn MerchantMenuItems__btn--secondary" onClick={onBack}>
-            {t('common.cancel')}
-          </button>
-          <button
-            type="submit"
-            className="MerchantMenuItems__btn MerchantMenuItems__btn--primary"
-            disabled={saving}
-          >
-            {saving ? t('merchant.saving') : isEdit ? t('common.update') : t('common.create')}
-          </button>
-        </div>
-      </form>
-    </div>
+                )}
+                <FormLayout.Group>
+                  <Button onClick={onBack}>{t('common.cancel')}</Button>
+                  <Button primary submit loading={saving}>
+                    {saving ? t('merchant.saving') : isEdit ? t('common.update') : t('common.create')}
+                  </Button>
+                </FormLayout.Group>
+              </FormLayout>
+            </Form>
+          </Card>
+        </Layout.Section>
+      </Layout>
+    </MerchantAdminLayout>
   );
 }

--- a/src/client/js/pages/MerchantMenus.tsx
+++ b/src/client/js/pages/MerchantMenus.tsx
@@ -1,20 +1,25 @@
 import React, { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import {
+  Banner,
+  Button,
+  Card,
+  Checkbox,
+  ChoiceList,
+  EmptyState,
+  Form,
+  FormLayout,
+  IndexTable,
+  Layout,
+  Page,
+  Spinner,
+  TextField,
+} from '@shopify/polaris';
+import MerchantAdminLayout from '../components/MerchantAdminLayout';
+import MerchantPolarisProvider from '../components/MerchantPolarisProvider';
+import { deleteApi, fetchApi } from '../lib/merchantApi';
 
 const DAYS = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'];
-
-const PRIORITY_TIMEZONES = [
-  'Asia/Kuala_Lumpur',
-  'Asia/Singapore',
-  'America/New_York',
-  'America/Chicago',
-  'America/Denver',
-  'America/Los_Angeles',
-];
-
-function fetchJson(url: string, opts?: RequestInit) {
-  return fetch(url, { credentials: 'same-origin', ...opts }).then((r) => r.json());
-}
 
 export default function MerchantMenus(props: any) {
   const { t } = useTranslation();
@@ -27,7 +32,7 @@ export default function MerchantMenus(props: any) {
     if (path.endsWith('/add')) {
       setView('add');
     } else {
-      const m = path.match(/\/menus\/(\d+)\/edit/);
+      const m = path.match(/\/online-menus\/(\d+)\/edit/);
       if (m) {
         setView('edit');
         setEditMenuId(parseInt(m[1], 10));
@@ -41,32 +46,59 @@ export default function MerchantMenus(props: any) {
   const navigate = (path: string) => props.history.push(path);
 
   if (!merchantUuid) {
-    return <div className="max-w-2xl mx-auto p-8 text-gray-400">{t('merchant.noUuid')}</div>;
+    return (
+      <MerchantPolarisProvider>
+        <Page title={t('menus.yourMenus')}>
+          <Banner status="critical">{t('merchant.noUuid')}</Banner>
+        </Page>
+      </MerchantPolarisProvider>
+    );
   }
 
   if (view === 'add') {
-    return <MenuForm merchantUuid={merchantUuid} onBack={() => navigate(`/merchant-dashboard/${merchantUuid}/online-menus`)} onSaved={() => navigate(`/merchant-dashboard/${merchantUuid}/online-menus`)} t={t} />;
+    return (
+      <MenuForm
+        merchantUuid={merchantUuid}
+        onBack={() => navigate(`/merchant-dashboard/${merchantUuid}/online-menus`)}
+        onSaved={() => navigate(`/merchant-dashboard/${merchantUuid}/online-menus`)}
+        t={t}
+      />
+    );
   }
 
   if (view === 'edit' && editMenuId) {
-    return <MenuForm merchantUuid={merchantUuid} menuId={editMenuId} onBack={() => navigate(`/merchant-dashboard/${merchantUuid}/online-menus`)} onSaved={() => navigate(`/merchant-dashboard/${merchantUuid}/online-menus`)} t={t} />;
+    return (
+      <MenuForm
+        merchantUuid={merchantUuid}
+        menuId={editMenuId}
+        onBack={() => navigate(`/merchant-dashboard/${merchantUuid}/online-menus`)}
+        onSaved={() => navigate(`/merchant-dashboard/${merchantUuid}/online-menus`)}
+        t={t}
+      />
+    );
   }
 
   return <MenuList merchantUuid={merchantUuid} navigate={navigate} t={t} />;
 }
 
-// ─── Menu List ───
-
-function MenuList({ merchantUuid, navigate, t }: { merchantUuid: string; navigate: (path: string) => void; t: (key: string) => string }) {
+function MenuList({
+  merchantUuid,
+  navigate,
+  t,
+}: {
+  merchantUuid: string;
+  navigate: (path: string) => void;
+  t: (key: string) => string;
+}) {
   const [merchant, setMerchant] = useState<any>(null);
   const [menus, setMenus] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    fetchJson(`/api/merchants/${merchantUuid}`)
+    fetchApi(`/api/merchants/${merchantUuid}`)
       .then((merchData) => {
         setMerchant(merchData);
-        return fetchJson(`/api/merchants/${merchData.id}/menus`);
+        return fetchApi(`/api/merchants/${merchData.id}/menus`);
       })
       .then((menuData) => setMenus(menuData.menus || []))
       .finally(() => setLoading(false));
@@ -88,80 +120,93 @@ function MenuList({ merchantUuid, navigate, t }: { merchantUuid: string; navigat
   const deleteMenu = async (menuId: number) => {
     if (!merchant?.id) return;
     if (!confirm(t('menus.confirmDelete'))) return;
-    await fetch(`/api/merchants/${merchant.id}/menus/${menuId}`, {
-      method: 'DELETE',
-      credentials: 'same-origin',
-    });
+    await deleteApi(`/api/merchants/${merchant.id}/menus/${menuId}`);
     setMenus((prev) => prev.filter((m) => m.id !== menuId));
   };
 
   if (loading) {
-    return <div className="max-w-2xl mx-auto p-8 text-gray-400">{t('common.loading')}</div>;
+    return (
+      <MerchantPolarisProvider>
+        <Page title={t('menus.yourMenus')}>
+          <Spinner accessibilityLabel={t('common.loading')} size="large" />
+        </Page>
+      </MerchantPolarisProvider>
+    );
   }
 
+  const rowMarkup = menus.map((menu, index) => (
+    <IndexTable.Row id={String(menu.id)} key={menu.id} position={index}>
+      <IndexTable.Cell>{menu.name}</IndexTable.Cell>
+      <IndexTable.Cell>
+        {menu.item_count} {t('menus.items')}
+        {menu.slug ? ` · ${menu.slug}` : ''}
+      </IndexTable.Cell>
+      <IndexTable.Cell>
+        <Checkbox
+          label={t('menus.published')}
+          labelHidden
+          checked={!!menu.is_published}
+          onChange={() => togglePublished(menu.id, !!menu.is_published)}
+        />
+      </IndexTable.Cell>
+      <IndexTable.Cell>
+        <Button plain onClick={() => navigate(`/merchant-dashboard/${merchantUuid}/online-menus/${menu.id}/edit`)}>
+          {t('common.edit')}
+        </Button>
+        {' · '}
+        <Button plain destructive onClick={() => deleteMenu(menu.id)}>
+          {t('common.delete')}
+        </Button>
+      </IndexTable.Cell>
+    </IndexTable.Row>
+  ));
+
   return (
-    <div className="max-w-2xl mx-auto p-4">
-      <div className="flex items-center justify-between mb-4">
-        <button onClick={() => navigate(`/merchant-dashboard/${merchantUuid}`)} className="text-blue-600 text-sm">
-          ← {t('merchant.backToOrders')}
-        </button>
-        <h1 className="text-lg font-bold text-gray-800">{t('menus.yourMenus')}</h1>
-        <button
-          onClick={() => navigate(`/merchant-dashboard/${merchantUuid}/online-menus/add`)}
-          className="bg-blue-600 hover:bg-blue-700 text-white text-sm px-4 py-2 rounded-lg font-medium"
-        >
-          + {t('menus.newMenu')}
-        </button>
-      </div>
-
-      {menus.length === 0 ? (
-        <p className="text-center text-gray-400 py-12">{t('menus.noMenus')}</p>
-      ) : (
-        <div className="space-y-3">
-          {menus.map((menu) => (
-            <div key={menu.id} className="bg-white border border-gray-200 rounded-xl p-4">
-              <div className="flex items-center justify-between mb-1">
-                <h2 className="font-semibold text-gray-800">{menu.name}</h2>
-                <label className="relative inline-flex items-center cursor-pointer flex-shrink-0 ml-3">
-                  <input
-                    type="checkbox"
-                    checked={!!menu.is_published}
-                    onChange={() => togglePublished(menu.id, !!menu.is_published)}
-                    className="sr-only peer"
-                  />
-                  <div className="w-9 h-5 bg-gray-200 peer-focus:ring-2 peer-focus:ring-blue-300 rounded-full peer peer-checked:bg-blue-600 peer-checked:after:translate-x-full after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:rounded-full after:h-4 after:w-4 after:transition-all" />
-                </label>
-              </div>
-              <p className="text-sm text-gray-500 mb-2">
-                {menu.item_count} {t('menus.items')}
-                {menu.slug && <span className="block text-xs text-gray-400 truncate">{menu.slug}</span>}
-              </p>
-              <div className="flex gap-2">
-                <button
-                  onClick={() => navigate(`/merchant-dashboard/${merchantUuid}/online-menus/${menu.id}/edit`)}
-                  className="text-blue-600 hover:underline text-sm"
-                >
-                  {t('common.edit')}
-                </button>
-                <button onClick={() => deleteMenu(menu.id)} className="text-red-500 hover:underline text-sm">
-                  {t('common.delete')}
-                </button>
-              </div>
-            </div>
-          ))}
-        </div>
-      )}
-
-      <div className="mt-6 border-t border-gray-100 pt-4">
-        <a href={`/merchant-dashboard/${merchantUuid}/menuitems`} className="text-sm text-gray-500 hover:underline">
-          {t('merchant.menuItems')} →
-        </a>
-      </div>
-    </div>
+    <MerchantAdminLayout
+      merchantUuid={merchantUuid}
+      title={t('menus.yourMenus')}
+      backLabel={t('merchant.backToOrders')}
+      onBack={() => navigate(`/merchant-dashboard/${merchantUuid}`)}
+      primaryAction={{
+        content: t('menus.newMenu'),
+        onAction: () => navigate(`/merchant-dashboard/${merchantUuid}/online-menus/add`),
+      }}
+    >
+      <Layout>
+        <Layout.Section>
+          {menus.length === 0 ? (
+            <Card sectioned>
+              <EmptyState
+                heading={t('menus.noMenus')}
+                action={{
+                  content: t('menus.newMenu'),
+                  onAction: () => navigate(`/merchant-dashboard/${merchantUuid}/online-menus/add`),
+                }}
+                image="https://cdn.shopify.com/s/files/1/0262/4071/2726/files/emptystate-files.png"
+              />
+            </Card>
+          ) : (
+            <Card>
+              <IndexTable
+                resourceName={{ singular: 'menu', plural: 'menus' }}
+                itemCount={menus.length}
+                headings={[
+                  { title: t('menus.menuName') },
+                  { title: t('menus.menuDescription') },
+                  { title: t('menus.published') },
+                  { title: '' },
+                ]}
+                selectable={false}
+              >
+                {rowMarkup}
+              </IndexTable>
+            </Card>
+          )}
+        </Layout.Section>
+      </Layout>
+    </MerchantAdminLayout>
   );
 }
-
-// ─── Menu Form (Create / Edit) ───
 
 function MenuForm({
   merchantUuid,
@@ -181,42 +226,33 @@ function MenuForm({
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
 
-  // Form state
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
   const [isPublished, setIsPublished] = useState(false);
   const [businessHours, setBusinessHours] = useState<Record<string, { open: string; close: string } | null>>({});
-
-  // If editing, load menu data
-  const [existingMenu, setExistingMenu] = useState<any>(null);
-  const [existingItemIds, setExistingItemIds] = useState<Set<number>>(new Set());
+  const [selectedItemIds, setSelectedItemIds] = useState<string[]>([]);
 
   useEffect(() => {
-    fetchJson(`/api/merchants/${merchantUuid}`)
+    fetchApi(`/api/merchants/${merchantUuid}`)
       .then(async (merch) => {
         setMerchant(merch);
-        const [itemsData] = await Promise.all([
-          fetchJson(`/api/merchants/${merch.id}/menu-items`),
-          menuId ? fetchJson(`/api/merchants/${merch.id}/menus/${menuId}`) : Promise.resolve(null),
-        ]);
+        const itemsData = await fetchApi(`/api/merchants/${merch.id}/menu-items`);
         setMenuItems(itemsData.menuItems || []);
 
-        if (menuId && itemsData) {
-          // Load existing menu for editing
-          const menuData = await fetchJson(`/api/merchants/${merch.id}/menus/${menuId}`);
+        if (menuId) {
+          const menuData = await fetchApi(`/api/merchants/${merch.id}/menus/${menuId}`);
           const menu = menuData.menu;
-          setExistingMenu(menu);
           setName(menu.name || '');
           setDescription(menu.description || '');
           setIsPublished(!!menu.is_published);
           setBusinessHours(menu.business_hours || {});
-          setExistingItemIds(new Set((menu.menuItems || []).map((i: any) => i.id)));
+          const ids = (menu.menuItems || []).map((i: any) => i.id);
+          setSelectedItemIds(ids.map(String));
         }
       })
       .finally(() => setLoading(false));
   }, [merchantUuid, menuId]);
 
-  // Business hours helpers
   const getHours = (day: string): { open: string; close: string } | null => {
     return (businessHours as any)?.[day] || null;
   };
@@ -230,23 +266,7 @@ function MenuForm({
     setHours(day, current ? null : { open: '09:00', close: '17:00' });
   };
 
-  // Menu item selection
-  const [selectedItemIds, setSelectedItemIds] = useState<Set<number>>(new Set());
-  useEffect(() => {
-    setSelectedItemIds(existingItemIds);
-  }, [existingItemIds]);
-
-  const toggleItem = (itemId: number) => {
-    setSelectedItemIds((prev) => {
-      const next = new Set(prev);
-      if (next.has(itemId)) next.delete(itemId);
-      else next.add(itemId);
-      return next;
-    });
-  };
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
+  const handleSubmit = async () => {
     if (!merchant?.id) return;
     setSaving(true);
 
@@ -255,7 +275,7 @@ function MenuForm({
       description: description || null,
       isPublished,
       businessHours,
-      menuItemIds: Array.from(selectedItemIds),
+      menuItemIds: selectedItemIds.map((id) => parseInt(id, 10)),
     };
 
     const url = menuId
@@ -273,134 +293,108 @@ function MenuForm({
     if (res.ok) onSaved();
   };
 
-  if (loading) return <div className="max-w-2xl mx-auto p-8 text-gray-400">{t('common.loading')}</div>;
+  if (loading) {
+    return (
+      <MerchantPolarisProvider>
+        <Page title={menuId ? t('menus.editMenu') : t('menus.newMenu')}>
+          <Spinner accessibilityLabel={t('common.loading')} size="large" />
+        </Page>
+      </MerchantPolarisProvider>
+    );
+  }
+
+  const itemChoices = menuItems.map((item: any) => ({
+    label: `${item.name} — $${(item.price_cents / 100).toFixed(2)}`,
+    value: String(item.id),
+  }));
 
   return (
-    <div className="max-w-2xl mx-auto p-4">
-      <div className="flex items-center mb-4">
-        <button onClick={onBack} className="text-blue-600 text-sm mr-auto">
-          ← {t('merchant.backToOrders')}
-        </button>
-        <h1 className="text-lg font-bold text-gray-800">
-          {menuId ? t('menus.editMenu') : t('menus.newMenu')}
-        </h1>
-      </div>
+    <MerchantAdminLayout
+      merchantUuid={merchantUuid}
+      title={menuId ? t('menus.editMenu') : t('menus.newMenu')}
+      backLabel={t('merchant.backToOrders')}
+      onBack={onBack}
+      showNav={false}
+    >
+      <Layout>
+        <Layout.Section>
+          <Card sectioned>
+            <Form onSubmit={handleSubmit}>
+              <FormLayout>
+                <TextField
+                  label={t('menus.menuName')}
+                  value={name}
+                  onChange={setName}
+                  autoComplete="off"
+                  placeholder={t('menus.menuNamePlaceholder')}
+                  requiredIndicator
+                />
+                <TextField
+                  label={t('menus.menuDescription')}
+                  value={description}
+                  onChange={setDescription}
+                  autoComplete="off"
+                />
+                <Checkbox label={t('menus.published')} checked={isPublished} onChange={setIsPublished} />
 
-      <form onSubmit={handleSubmit} className="space-y-6">
-        {/* Name */}
-        <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">{t('menus.menuName')} *</label>
-          <input
-            type="text"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            required
-            className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-            placeholder={t('menus.menuNamePlaceholder')}
-          />
-        </div>
+                <FormLayout.Group title={t('menus.businessHours')}>
+                  <p style={{ margin: 0, color: '#6d7175', fontSize: 13 }}>{t('menus.businessHoursHint')}</p>
+                  {DAYS.map((day) => {
+                    const hours = getHours(day);
+                    return (
+                      <div key={day} style={{ display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap' }}>
+                        <Checkbox label={day} checked={!!hours} onChange={() => toggleDay(day)} />
+                        {hours ? (
+                          <>
+                            <TextField
+                              label={`${day} open`}
+                              labelHidden
+                              value={hours.open}
+                              onChange={(value) => setHours(day, { ...hours, open: value })}
+                              type="time"
+                              autoComplete="off"
+                            />
+                            <span>–</span>
+                            <TextField
+                              label={`${day} close`}
+                              labelHidden
+                              value={hours.close}
+                              onChange={(value) => setHours(day, { ...hours, close: value })}
+                              type="time"
+                              autoComplete="off"
+                            />
+                          </>
+                        ) : (
+                          <span style={{ color: '#6d7175', fontSize: 13 }}>{t('menus.closed')}</span>
+                        )}
+                      </div>
+                    );
+                  })}
+                </FormLayout.Group>
 
-        {/* Description */}
-        <div>
-          <label className="block text-sm font-medium text-gray-700 mb-1">{t('menus.menuDescription')}</label>
-          <input
-            type="text"
-            value={description}
-            onChange={(e) => setDescription(e.target.value)}
-            className="w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-          />
-        </div>
-
-        {/* Published toggle */}
-        <div className="flex items-center justify-between">
-          <span className="text-sm font-medium text-gray-700">{t('menus.published')}</span>
-          <label className="relative inline-flex items-center cursor-pointer">
-            <input
-              type="checkbox"
-              checked={isPublished}
-              onChange={(e) => setIsPublished(e.target.checked)}
-              className="sr-only peer"
-            />
-            <div className="w-9 h-5 bg-gray-200 peer-focus:ring-2 peer-focus:ring-blue-300 rounded-full peer peer-checked:bg-blue-600 peer-checked:after:translate-x-full after:content-[''] after:absolute after:top-[2px] after:start-[2px] after:bg-white after:rounded-full after:h-4 after:w-4 after:transition-all" />
-          </label>
-        </div>
-
-        {/* Business hours */}
-        <div>
-          <h3 className="text-sm font-medium text-gray-700 mb-2">{t('menus.businessHours')}</h3>
-          <p className="text-xs text-gray-400 mb-3">{t('menus.businessHoursHint')}</p>
-          <div className="space-y-2">
-            {DAYS.map((day) => {
-              const hours = getHours(day);
-              return (
-                <div key={day} className="flex items-center gap-3">
-                  <label className="flex items-center gap-2 w-full">
-                    <input
-                      type="checkbox"
-                      checked={!!hours}
-                      onChange={() => toggleDay(day)}
-                      className="rounded"
-                    />
-                    <span className="text-sm text-gray-700 w-10 capitalize">{day}</span>
-                  </label>
-                  {hours ? (
-                    <div className="flex items-center gap-2">
-                      <input
-                        type="time"
-                        value={hours.open}
-                        onChange={(e) => setHours(day, { ...hours, open: e.target.value })}
-                        className="border border-gray-300 rounded px-2 py-1 text-sm w-28"
-                      />
-                      <span className="text-gray-400">–</span>
-                      <input
-                        type="time"
-                        value={hours.close}
-                        onChange={(e) => setHours(day, { ...hours, close: e.target.value })}
-                        className="border border-gray-300 rounded px-2 py-1 text-sm w-28"
-                      />
-                    </div>
-                  ) : (
-                    <span className="text-sm text-gray-400">{t('menus.closed')}</span>
-                  )}
-                </div>
-              );
-            })}
-          </div>
-        </div>
-
-        {/* Menu items selection */}
-        <div>
-          <h3 className="text-sm font-medium text-gray-700 mb-2">{t('menus.selectItems')}</h3>
-          {menuItems.length === 0 ? (
-            <p className="text-sm text-gray-400">{t('menus.noItemsYet')}</p>
-          ) : (
-            <div className="space-y-1 max-h-64 overflow-y-auto border border-gray-200 rounded-lg p-2">
-              {menuItems.map((item: any) => (
-                <label key={item.id} className="flex items-center gap-3 p-2 hover:bg-gray-50 rounded cursor-pointer">
-                  <input
-                    type="checkbox"
-                    checked={selectedItemIds.has(item.id)}
-                    onChange={() => toggleItem(item.id)}
-                    className="rounded"
+                {menuItems.length === 0 ? (
+                  <p style={{ margin: 0, color: '#6d7175' }}>{t('menus.noItemsYet')}</p>
+                ) : (
+                  <ChoiceList
+                    title={t('menus.selectItems')}
+                    allowMultiple
+                    choices={itemChoices}
+                    selected={selectedItemIds}
+                    onChange={setSelectedItemIds}
                   />
-                  <span className="text-sm text-gray-800 flex-1">{item.name}</span>
-                  <span className="text-sm text-gray-400">${(item.price_cents / 100).toFixed(2)}</span>
-                </label>
-              ))}
-            </div>
-          )}
-        </div>
+                )}
 
-        {/* Actions */}
-        <div className="flex gap-3 pt-4 border-t border-gray-100">
-          <button type="button" onClick={onBack} className="flex-1 text-sm text-gray-600 py-2 rounded-lg border border-gray-300 hover:bg-gray-50">
-            {t('common.cancel')}
-          </button>
-          <button type="submit" disabled={saving} className="flex-1 bg-blue-600 hover:bg-blue-700 text-white text-sm py-2 rounded-lg font-medium disabled:opacity-50">
-            {saving ? t('common.saving') : t('common.save')}
-          </button>
-        </div>
-      </form>
-    </div>
+                <FormLayout.Group>
+                  <Button onClick={onBack}>{t('common.cancel')}</Button>
+                  <Button primary submit loading={saving}>
+                    {saving ? t('merchant.saving') : t('common.save')}
+                  </Button>
+                </FormLayout.Group>
+              </FormLayout>
+            </Form>
+          </Card>
+        </Layout.Section>
+      </Layout>
+    </MerchantAdminLayout>
   );
 }

--- a/src/client/js/pages/MerchantSettings.tsx
+++ b/src/client/js/pages/MerchantSettings.tsx
@@ -1,26 +1,22 @@
 import React, { useEffect, useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
-import LangSwitcher from '../components/LangSwitcher';
+import {
+  Banner,
+  Button,
+  ButtonGroup,
+  Card,
+  Form,
+  FormLayout,
+  Layout,
+  Page,
+  Spinner,
+  TextField,
+} from '@shopify/polaris';
 import type { MerchantRow } from '../../../shared/merchants';
 import { resolveMerchantTheme } from '../../../shared/merchants';
-import '../../css/pages/MerchantSettings.css';
-
-function fetchApi(url: string) {
-  return fetch(url, { credentials: 'same-origin' as const }).then((r) => r.json());
-}
-
-function patchApi(url: string, body: any) {
-  return fetch(url, {
-    method: 'PATCH',
-    credentials: 'same-origin' as const,
-    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
-    body: JSON.stringify(body),
-  }).then(async (r) => {
-    const data = await r.json().catch(() => ({}));
-    if (!r.ok) throw new Error((data as any)?.error || 'Request failed');
-    return data;
-  });
-}
+import MerchantAdminLayout from '../components/MerchantAdminLayout';
+import MerchantPolarisProvider from '../components/MerchantPolarisProvider';
+import { fetchApi, patchApi } from '../lib/merchantApi';
 
 export default function MerchantSettings(props: any) {
   const { t } = useTranslation();
@@ -44,17 +40,21 @@ export default function MerchantSettings(props: any) {
 
   if (error) {
     return (
-      <div className="MerchantSettings MerchantSettings--error">
-        <div className="MerchantSettings__error">{error}</div>
-      </div>
+      <MerchantPolarisProvider>
+        <Page title={t('merchant.settings')}>
+          <Banner status="critical">{error}</Banner>
+        </Page>
+      </MerchantPolarisProvider>
     );
   }
 
   if (!merchant) {
     return (
-      <div className="MerchantSettings">
-        <div className="MerchantSettings__loading">{t('common.loading')}</div>
-      </div>
+      <MerchantPolarisProvider>
+        <Page title={t('merchant.settings')}>
+          <Spinner accessibilityLabel={t('common.loading')} size="large" />
+        </Page>
+      </MerchantPolarisProvider>
     );
   }
 
@@ -109,7 +109,7 @@ function SettingsForm({
     try {
       const data = await patchApi(`/api/merchants/${merchant.id}`, { theme: newTheme });
       onSave(data.merchant);
-    } catch (err) {
+    } catch {
       setSaveError(t('merchant.settingsSaveFailed'));
       setTheme(theme);
     } finally {
@@ -117,8 +117,7 @@ function SettingsForm({
     }
   };
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
+  const handleSubmit = async () => {
     if (!businessName.trim()) {
       setSaveError(t('merchant.businessNameRequired'));
       return;
@@ -133,121 +132,97 @@ function SettingsForm({
         addressStreet: addressStreet.trim() || null,
       });
       onSave(data.merchant);
-    } catch (err) {
+    } catch {
       setSaveError(t('merchant.settingsSaveFailed'));
     } finally {
       setSaving(false);
     }
   };
 
-  const themeValue = resolveMerchantTheme(merchant.theme);
-
   return (
-    <div className={`MerchantSettings MerchantSettings--theme-${themeValue}`}>
-      <header className="MerchantSettings__header">
-        <button type="button" className="MerchantSettings__back" onClick={onBack}>
-          {t('merchant.backToOrders')}
-        </button>
-        <h1 className="MerchantSettings__title">
-          {t('merchant.settings')} <LangSwitcher />
-        </h1>
-        <div className="MerchantSettings__nav">
-          <a href={`/merchant-dashboard/${merchantUuid}/online-menus`}>{t('merchant.menus')}</a>
-          <a href={`/merchant-dashboard/${merchantUuid}/menuitems`}>{t('merchant.menu')}</a>
-        </div>
-      </header>
+    <MerchantAdminLayout
+      merchantUuid={merchantUuid}
+      title={t('merchant.settings')}
+      backLabel={t('merchant.backToOrders')}
+      onBack={onBack}
+    >
+      <Layout>
+        {saveError && (
+          <Layout.Section>
+            <Banner status="critical" onDismiss={() => setSaveError(null)}>
+              {saveError}
+            </Banner>
+          </Layout.Section>
+        )}
 
-      <form className="MerchantSettings__form" onSubmit={handleSubmit}>
-        {saveError && <div className="MerchantSettings__error">{saveError}</div>}
+        <Layout.Section>
+          <Form onSubmit={handleSubmit}>
+            <FormLayout>
+              <Card title={t('merchant.businessInfo')} sectioned>
+                <FormLayout>
+                  <TextField
+                    label={t('merchant.businessName')}
+                    value={businessName}
+                    onChange={setBusinessName}
+                    autoComplete="organization"
+                    placeholder={t('merchant.businessNamePlaceholder')}
+                    requiredIndicator
+                  />
+                  <TextField
+                    label={t('merchant.taxId')}
+                    value={taxId}
+                    onChange={setTaxId}
+                    autoComplete="off"
+                    placeholder={t('merchant.taxIdPlaceholder')}
+                  />
+                  <TextField
+                    label={t('merchant.whatsappNumber')}
+                    value={whatsappNumber}
+                    onChange={setWhatsappNumber}
+                    type="tel"
+                    autoComplete="tel"
+                    placeholder={t('merchant.whatsappNumberPlaceholder')}
+                  />
+                  <TextField
+                    label={t('merchant.businessAddress')}
+                    value={addressStreet}
+                    onChange={setAddressStreet}
+                    multiline={3}
+                    autoComplete="street-address"
+                    placeholder={t('merchant.businessAddressPlaceholder')}
+                  />
+                </FormLayout>
+              </Card>
 
-        <section className="MerchantSettings__section">
-          <h2 className="MerchantSettings__sectionTitle">{t('merchant.businessInfo')}</h2>
+              <Card title={t('merchant.appearance')} sectioned>
+                <ButtonGroup segmented>
+                  <Button
+                    pressed={theme === 'light'}
+                    onClick={() => handleThemeChange('light')}
+                    disabled={saving}
+                  >
+                    {t('merchant.themeLight')}
+                  </Button>
+                  <Button
+                    pressed={theme === 'dark'}
+                    onClick={() => handleThemeChange('dark')}
+                    disabled={saving}
+                  >
+                    {t('merchant.themeDark')}
+                  </Button>
+                </ButtonGroup>
+              </Card>
 
-          <div className="MerchantSettings__field">
-            <label htmlFor="businessName">{t('merchant.businessName')} *</label>
-            <input
-              id="businessName"
-              type="text"
-              value={businessName}
-              onChange={(e) => setBusinessName(e.target.value)}
-              required
-              className="MerchantSettings__input"
-              placeholder={t('merchant.businessNamePlaceholder')}
-            />
-          </div>
-
-          <div className="MerchantSettings__field">
-            <label htmlFor="taxId">{t('merchant.taxId')}</label>
-            <input
-              id="taxId"
-              type="text"
-              value={taxId}
-              onChange={(e) => setTaxId(e.target.value)}
-              className="MerchantSettings__input"
-              placeholder={t('merchant.taxIdPlaceholder')}
-            />
-          </div>
-
-          <div className="MerchantSettings__field">
-            <label htmlFor="whatsappNumber">{t('merchant.whatsappNumber')}</label>
-            <input
-              id="whatsappNumber"
-              type="tel"
-              value={whatsappNumber}
-              onChange={(e) => setWhatsappNumber(e.target.value)}
-              className="MerchantSettings__input"
-              placeholder={t('merchant.whatsappNumberPlaceholder')}
-            />
-          </div>
-
-          <div className="MerchantSettings__field">
-            <label htmlFor="address">{t('merchant.businessAddress')}</label>
-            <textarea
-              id="address"
-              value={addressStreet}
-              onChange={(e) => setAddressStreet(e.target.value)}
-              className="MerchantSettings__input MerchantSettings__textarea"
-              rows={3}
-              placeholder={t('merchant.businessAddressPlaceholder')}
-            />
-          </div>
-        </section>
-
-        <section className="MerchantSettings__section">
-          <h2 className="MerchantSettings__sectionTitle">{t('merchant.appearance')}</h2>
-          <div className="MerchantSettings__themeToggle">
-            <button
-              type="button"
-              className={`MerchantSettings__themeBtn ${theme === 'light' ? 'MerchantSettings__themeBtn--active' : ''}`}
-              onClick={() => handleThemeChange('light')}
-              disabled={saving}
-            >
-              {t('merchant.themeLight')}
-            </button>
-            <button
-              type="button"
-              className={`MerchantSettings__themeBtn ${theme === 'dark' ? 'MerchantSettings__themeBtn--active' : ''}`}
-              onClick={() => handleThemeChange('dark')}
-              disabled={saving}
-            >
-              {t('merchant.themeDark')}
-            </button>
-          </div>
-        </section>
-
-        <div className="MerchantSettings__formActions">
-          <button type="button" className="MerchantSettings__btn MerchantSettings__btn--secondary" onClick={onBack}>
-            {t('common.cancel')}
-          </button>
-          <button
-            type="submit"
-            className="MerchantSettings__btn MerchantSettings__btn--primary"
-            disabled={saving}
-          >
-            {saving ? t('merchant.saving') : t('common.save')}
-          </button>
-        </div>
-      </form>
-    </div>
+              <FormLayout.Group>
+                <Button onClick={onBack}>{t('common.cancel')}</Button>
+                <Button primary submit loading={saving}>
+                  {saving ? t('merchant.saving') : t('common.save')}
+                </Button>
+              </FormLayout.Group>
+            </FormLayout>
+          </Form>
+        </Layout.Section>
+      </Layout>
+    </MerchantAdminLayout>
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Migrates merchant admin CRUD screens to **Shopify Polaris** for a consistent, production-quality admin UI.

- Adds `@shopify/polaris@^10` (React 16 compatible)
- Introduces shared `MerchantPolarisProvider` and `MerchantAdminLayout` wrappers
- Refactors these views to Polaris components:
  - **Settings** (`/merchant-dashboard/:uuid/settings`)
  - **Menu items** list/add/edit + modifiers modal
  - **Online menus** list/add/edit

## UI changes

- List views use Polaris `IndexTable`, `EmptyState`, and `Card`
- Forms use `FormLayout`, `TextField`, `Checkbox`, and `ChoiceList`
- Modifiers management uses Polaris `Modal` + `ResourceList`
- Shared page chrome via `Page` with back action and nav links (Menus, Menu Items, Settings)

## Notes

- Polaris v10 was chosen to stay compatible with the project's React 16 stack
- Merchant orders dashboard (`MerchantRoutes`) is unchanged — still the existing custom POS UI
- All existing API behavior is preserved; this is a frontend-only UI migration

## Test plan

- [x] `pnpm run build`
- [x] `pnpm test` (66 passing)
- [x] Verified merchant CRUD routes return 200 locally (`settings`, `menuitems`, `online-menus`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a40c83aa-4442-409d-86c8-ee5fd50c58b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a40c83aa-4442-409d-86c8-ee5fd50c58b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

