### PR TITLE
Add post-deploy smoke test for Railway staging

### DIFF
--- a/.cursor/rules/post-deploy-smoke-test.mdc
+++ b/.cursor/rules/post-deploy-smoke-test.mdc
@@ -1,0 +1,17 @@
+---
+description: Run post-deploy smoke tests against Railway staging after every deploy
+globs:
+alwaysApply: false
+---
+
+# Post-deploy smoke test (Railway staging)
+
+After every deploy to staging or when the user mentions Railway/production issues:
+
+1. Run `pnpm run smoke:staging` against https://eggrollpos-staging.up.railway.app/
+2. If merchant/menu checks are skipped, ask for or use Railway env vars `STAGING_MERCHANT_KEY` and `STAGING_MENU_SLUG` from the staging database.
+3. Treat **JS bundle returning text/html** as a production asset-path regression (see `src/server/lib/viteAssets.js`).
+4. Do not assume seed routes (`mc_m4zun00d`, `instep-cafe-...`) exist on staging unless seeds were run.
+5. Summarize failures with the failing URL and HTTP status/content-type.
+
+Skill details: `.cursor/skills/post-deploy-smoke-test/SKILL.md`

--- a/.cursor/skills/post-deploy-smoke-test/SKILL.md
+++ b/.cursor/skills/post-deploy-smoke-test/SKILL.md
@@ -1,0 +1,87 @@
+# Post-deploy smoke test
+
+Run after every Railway deploy to **staging** (or production) to confirm the app is serving pages and assets correctly.
+
+## Default staging URL
+
+https://eggrollpos-staging.up.railway.app/
+
+## When to run
+
+- After merging to `main` and Railway finishes deploy
+- After changing frontend build, EJS shell, Dockerfile, or static asset paths
+- After database migrations on staging
+- When debugging blank pages or MIME type errors in the browser
+
+## Command
+
+```bash
+pnpm run smoke:staging
+```
+
+Or with explicit env:
+
+```bash
+BASE_URL=https://eggrollpos-staging.up.railway.app \
+STAGING_MERCHANT_KEY=mc_your_hash \
+STAGING_MENU_SLUG=your-published-menu-slug \
+node scripts/smoke-test-deploy.js
+```
+
+## What it checks
+
+Always (no extra env):
+
+| Check | Expect |
+|-------|--------|
+| `GET /health` | `200`, `{ "status": "ok" }` |
+| `GET /` | `200`, `#app-root`, page title `eggroll pos demo` |
+| `GET /about` | `200`, `#app-root` |
+| Vite JS bundle | `200`, **not** `text/html` (catches broken asset paths) |
+
+With `STAGING_MERCHANT_KEY` (hash_id **or** UUID):
+
+| Check |
+|-------|
+| `GET /api/merchants/:key` |
+| `/merchant-dashboard/:key` |
+| `/merchant-dashboard/:key/menuitems` |
+| `/merchant-dashboard/:key/settings` |
+| `/merchant-dashboard/:key/online-menus` |
+
+With `STAGING_MENU_SLUG`:
+
+| Check |
+|-------|
+| `GET /api/menus/:slug` |
+| `/online-ordering/:slug` |
+| `/online-ordering/:slug/checkout` |
+
+With `STAGING_RECEIPT_UUID`:
+
+| Check |
+|-------|
+| `/receipts/:uuid` |
+| `GET /r/:uuid` |
+
+## Agent workflow after deploy
+
+1. Wait for Railway deploy to finish (health check green).
+2. Run `pnpm run smoke:staging` with staging env vars set if available.
+3. If failures mention **HTML MIME type for JS** or **missing #app-root**, inspect `src/server/views/index.ejs` and Vite manifest wiring (`src/server/lib/viteAssets.js`).
+4. If merchant routes fail with 404, verify `STAGING_MERCHANT_KEY` matches a merchant created via `pnpm run create-merchant` on staging — seed UUIDs like `mc_m4zun00d` are **local dev only**.
+5. Report pass/fail summary to the user; do not mark deploy complete if smoke test fails.
+
+## Railway env suggestion
+
+Set on the **staging** service (for smoke tests run from CI or local):
+
+```
+STAGING_MERCHANT_KEY=<hash_id from create-merchant>
+STAGING_MENU_SLUG=<published menu slug>
+```
+
+## Exit codes
+
+- `0` — all executed checks passed
+- `1` — one or more checks failed

--- a/.env.staging.example
+++ b/.env.staging.example
@@ -1,0 +1,5 @@
+# Smoke test targets (copy values from your staging Railway DB)
+BASE_URL=https://eggrollpos-staging.up.railway.app
+STAGING_MERCHANT_KEY=mc_your_hash_from_create_merchant
+STAGING_MENU_SLUG=your-published-menu-slug
+# STAGING_RECEIPT_UUID=order-uuid-after-test-checkout

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,28 @@ Webhook endpoint (mounted when `WHATSAPP_VERIFY_TOKEN` or `WHATSAPP_ENABLED` is 
 
 Copy `.env.example` for variable names. Local testing requires an HTTPS tunnel (ngrok, Cloudflare) pointing at port 3000. See `docs/whatsapp-integration.md`.
 
+### Post-deploy smoke test (Railway staging)
+
+After every deploy to **https://eggrollpos-staging.up.railway.app/**, run:
+
+```bash
+pnpm run smoke:staging
+```
+
+Optional env for full route coverage (see `.env.staging.example`):
+
+```bash
+STAGING_MERCHANT_KEY=mc_... STAGING_MENU_SLUG=... pnpm run smoke:staging
+```
+
+The script checks `/health`, SPA pages (`/`, `/about`), Vite JS bundle MIME types, and (when env is set) merchant dashboard, online ordering, and receipt routes. Do not mark a deploy complete if smoke tests fail.
+
+- Script: `scripts/smoke-test-deploy.js`
+- Cursor skill: `.cursor/skills/post-deploy-smoke-test/SKILL.md`
+- Cursor rule: `.cursor/rules/post-deploy-smoke-test.mdc`
+
+Staging DB merchants come from `pnpm run create-merchant` — local seed UUIDs/slugs may not exist on Railway.
+
 ### Optional integrations
 
 The contact form currently logs submissions to stdout; a database-backed admin UI is planned.

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     "db:migrate:rollback": "knex migrate:rollback --knexfile db/knexfile.js",
     "db:seed": "knex seed:run --knexfile db/knexfile.js",
     "db:seed:menus": "knex seed:run --specific=07_menus.js --knexfile db/knexfile.js",
-    "db:reset": "knex migrate:rollback --all --knexfile db/knexfile.js && knex migrate:latest --knexfile db/knexfile.js && knex seed:run --knexfile db/knexfile.js"
+    "db:reset": "knex migrate:rollback --all --knexfile db/knexfile.js && knex migrate:latest --knexfile db/knexfile.js && knex seed:run --knexfile db/knexfile.js",
+    "smoke:staging": "node scripts/smoke-test-deploy.js",
+    "smoke:deploy": "node scripts/smoke-test-deploy.js"
   },
   "engines": {
     "node": ">=22.14.0"

--- a/scripts/smoke-test-deploy.js
+++ b/scripts/smoke-test-deploy.js
@@ -1,0 +1,143 @@
+#!/usr/bin/env node
+/**
+ * Post-deploy smoke test for eggroll-pos (staging/production).
+ *
+ * Usage:
+ *   pnpm run smoke:staging
+ *   BASE_URL=https://eggrollpos-staging.up.railway.app node scripts/smoke-test-deploy.js
+ *
+ * Optional env (required for merchant/menu/receipt checks on non-seeded DBs):
+ *   STAGING_MERCHANT_KEY   hash_id or UUID (e.g. mc_abc123)
+ *   STAGING_MENU_SLUG      published menu slug
+ *   STAGING_RECEIPT_UUID   order UUID for receipt page
+ */
+
+const BASE_URL = (process.env.BASE_URL || 'https://eggrollpos-staging.up.railway.app').replace(/\/$/, '');
+const MERCHANT_KEY = process.env.STAGING_MERCHANT_KEY || process.env.SMOKE_MERCHANT_KEY || '';
+const MENU_SLUG = process.env.STAGING_MENU_SLUG || process.env.SMOKE_MENU_SLUG || '';
+const RECEIPT_UUID = process.env.STAGING_RECEIPT_UUID || process.env.SMOKE_RECEIPT_UUID || '';
+
+const failures = [];
+const passes = [];
+
+function pass(name, detail) {
+  passes.push({ name, detail });
+  console.log(`✓ ${name}${detail ? ` — ${detail}` : ''}`);
+}
+
+function fail(name, detail) {
+  failures.push({ name, detail });
+  console.error(`✗ ${name}${detail ? ` — ${detail}` : ''}`);
+}
+
+async function fetchResponse(path, opts = {}) {
+  const url = `${BASE_URL}${path}`;
+  const res = await fetch(url, {
+    redirect: 'follow',
+    ...opts,
+    headers: { Accept: opts.accept || '*/*', ...(opts.headers || {}) },
+  });
+  const contentType = res.headers.get('content-type') || '';
+  let body = '';
+  if (opts.readBody !== false) {
+    body = await res.text();
+  }
+  return { url, res, status: res.status, contentType, body };
+}
+
+async function checkHealth() {
+  const { status, body, contentType } = await fetchResponse('/health');
+  if (status !== 200) return fail('GET /health', `status ${status}`);
+  if (!contentType.includes('json')) return fail('GET /health', `expected JSON, got ${contentType}`);
+  try {
+    const data = JSON.parse(body);
+    if (data.status !== 'ok') return fail('GET /health', `body ${body}`);
+  } catch {
+    return fail('GET /health', 'invalid JSON');
+  }
+  pass('GET /health', 'database ok');
+}
+
+async function checkSpaPage(name, path, mustInclude = []) {
+  const { status, body, contentType } = await fetchResponse(path, {
+    headers: { Accept: 'text/html' },
+  });
+  if (status !== 200) return fail(name, `status ${status}`);
+  if (!contentType.includes('html')) return fail(name, `expected HTML, got ${contentType}`);
+  if (!body.includes('id="app-root"') && !body.includes("id='app-root'")) {
+    return fail(name, 'missing #app-root');
+  }
+  for (const needle of mustInclude) {
+    if (!body.includes(needle)) return fail(name, `missing "${needle}"`);
+  }
+
+  const scriptMatch = body.match(/<script[^>]+type="module"[^>]+src="([^"]+)"/);
+  if (!scriptMatch) return fail(name, 'no module script tag in HTML');
+  const scriptPath = scriptMatch[1];
+  const asset = await fetchResponse(scriptPath, { accept: 'application/javascript' });
+  if (asset.status !== 200) return fail(name, `JS asset ${scriptPath} status ${asset.status}`);
+  if (asset.contentType.includes('text/html')) {
+    return fail(name, `JS asset ${scriptPath} returned HTML (MIME bug)`);
+  }
+  pass(name, scriptPath);
+}
+
+async function checkJsonApi(name, path, predicate) {
+  const { status, body, contentType } = await fetchResponse(path, {
+    headers: { Accept: 'application/json' },
+  });
+  if (status !== 200) return fail(name, `status ${status}`);
+  if (!contentType.includes('json')) return fail(name, `expected JSON, got ${contentType}`);
+  try {
+    const data = JSON.parse(body);
+    if (predicate && !predicate(data)) return fail(name, 'unexpected response shape');
+  } catch {
+    return fail(name, 'invalid JSON');
+  }
+  pass(name);
+}
+
+async function main() {
+  console.log(`Smoke test: ${BASE_URL}\n`);
+
+  await checkHealth();
+
+  await checkSpaPage('GET /', '/');
+  await checkSpaPage('GET /about', '/about');
+  await checkSpaPage('GET / (title)', '/', ['eggroll pos demo']);
+
+  if (MERCHANT_KEY) {
+    await checkJsonApi(`GET /api/merchants/${MERCHANT_KEY}`, `/api/merchants/${MERCHANT_KEY}`, (d) => d && d.id);
+    await checkSpaPage('GET /merchant-dashboard', `/merchant-dashboard/${MERCHANT_KEY}`);
+    await checkSpaPage('GET /merchant-dashboard/menuitems', `/merchant-dashboard/${MERCHANT_KEY}/menuitems`);
+    await checkSpaPage('GET /merchant-dashboard/settings', `/merchant-dashboard/${MERCHANT_KEY}/settings`);
+    await checkSpaPage('GET /merchant-dashboard/online-menus', `/merchant-dashboard/${MERCHANT_KEY}/online-menus`);
+  } else {
+    console.log('○ Skipping merchant routes (set STAGING_MERCHANT_KEY)');
+  }
+
+  if (MENU_SLUG) {
+    await checkJsonApi(`GET /api/menus/${MENU_SLUG}`, `/api/menus/${MENU_SLUG}`, (d) => d && d.menu);
+    await checkSpaPage('GET /online-ordering', `/online-ordering/${MENU_SLUG}`);
+    await checkSpaPage('GET /online-ordering/checkout', `/online-ordering/${MENU_SLUG}/checkout`);
+  } else {
+    console.log('○ Skipping online ordering routes (set STAGING_MENU_SLUG)');
+  }
+
+  if (RECEIPT_UUID) {
+    await checkSpaPage('GET /receipts', `/receipts/${RECEIPT_UUID}`);
+    await checkJsonApi(`GET /r/${RECEIPT_UUID}`, `/r/${RECEIPT_UUID}`, (d) => d && d.receipt);
+  } else {
+    console.log('○ Skipping receipt routes (set STAGING_RECEIPT_UUID)');
+  }
+
+  console.log(`\n${passes.length} passed, ${failures.length} failed`);
+  if (failures.length) {
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a repeatable post-deploy smoke test workflow for Railway staging at https://eggrollpos-staging.up.railway.app/

## What's included

- **`scripts/smoke-test-deploy.js`** — checks `/health`, SPA pages (`/`, `/about`), page title, and Vite JS bundle MIME types (catches broken asset paths). Optional env vars enable merchant dashboard, online ordering, and receipt route checks.
- **`pnpm run smoke:staging`** — npm script to run the smoke test with staging as the default base URL.
- **`.cursor/skills/post-deploy-smoke-test/SKILL.md`** — agent skill with full workflow and troubleshooting notes.
- **`.cursor/rules/post-deploy-smoke-test.mdc`** — Cursor rule to invoke smoke tests after deploy-related work.
- **`.env.staging.example`** — template for staging-specific merchant/menu keys.
- **`AGENTS.md`** — documents the post-deploy requirement for cloud agents.

## Verification

Ran against staging before commit:

```
✓ GET /health — database ok
✓ GET / — /assets/index-HFUx0kmW.js
✓ GET /about — /assets/index-HFUx0kmW.js
✓ GET / (title) — /assets/index-HFUx0kmW.js
4 passed, 0 failed
```

Merchant/menu/receipt checks are skipped until `STAGING_MERCHANT_KEY` and `STAGING_MENU_SLUG` are set from the staging database.

## Usage after deploy

```bash
pnpm run smoke:staging
# or with full coverage:
STAGING_MERCHANT_KEY=mc_... STAGING_MENU_SLUG=... pnpm run smoke:staging
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a40c83aa-4442-409d-86c8-ee5fd50c58b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a40c83aa-4442-409d-86c8-ee5fd50c58b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

