### PR TITLE
Fix menu item images not loading (serve via /media proxy)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,5 +21,5 @@ WHATSAPP_API_VERSION=v25.0
 # S3_ACCESS_KEY_ID=
 # S3_SECRET_ACCESS_KEY=
 # S3_REGION=auto
-# Optional public URL base (defaults to ENDPOINT/BUCKET)
-# S3_PUBLIC_URL=https://...
+# Railway buckets are private — images are served via GET /media/* on this app (not direct bucket URLs).
+# S3_FORCE_PATH_STYLE=true  # only if your bucket Credentials tab requires path-style URLs

--- a/.env.production.example
+++ b/.env.production.example
@@ -21,5 +21,5 @@ S3_BUCKET=
 S3_ACCESS_KEY_ID=
 S3_SECRET_ACCESS_KEY=
 S3_REGION=auto
-# Optional override for public image URLs (defaults to ENDPOINT/BUCKET)
-# S3_PUBLIC_URL=
+# Railway buckets are private — images are served via GET /media/* on this app.
+# S3_FORCE_PATH_STYLE=true  # only if bucket Credentials tab requires path-style

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -92,15 +92,15 @@ On **first deploy** (empty `merchants` table), the container entrypoint runs dev
 
 1. **Add service → Object Storage** (or attach a bucket to the app).
 2. Copy the S3-compatible variables into the app service:
-   - `S3_ENDPOINT`
-   - `S3_BUCKET`
+   - `S3_ENDPOINT` (e.g. `https://t3.storageapi.dev`)
+   - `S3_BUCKET` (the bucket name from the Credentials tab)
    - `S3_ACCESS_KEY_ID`
    - `S3_SECRET_ACCESS_KEY`
    - `S3_REGION` (often `auto`)
-3. Make the bucket **public read** for development (images are served directly to customers).
-4. Optional: set `S3_PUBLIC_URL` if the public base URL differs from `ENDPOINT/BUCKET`.
+3. **Do not** point browsers at the bucket URL directly — Railway buckets are **private** and return 403. The app serves images at **`/media/menu-items/...`** using server-side credentials.
+4. Use **virtual-hosted-style** URLs for the S3 API (default). Only set `S3_FORCE_PATH_STYLE=true` if your bucket Credentials tab says path-style is required.
 
-Upload flow: merchant add/edit form → presigned PUT to bucket → server completes upload (resize if &gt; 200 KB) → `image_url` saved on the menu item.
+Upload flow: merchant add/edit form → presigned PUT to bucket → server completes upload (resize if &gt; 200 KB) → `image_url` saved as `/media/menu-items/{hash_id}/{menu_item_id}/{uuid}.ext` → list and online ordering load images through the app proxy.
 
 ### 3. Configure the app service
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqc-nodejs-demo",
-  "version": "0.6.0",
+  "version": "0.7.1",
   "private": true,
   "main": "src/server/index.js",
   "scripts": {

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -10,6 +10,7 @@ const leadsRouter = require("./routes/leads");
 const merchantsRouter = require("./routes/merchants");
 const ordersRouter = require("./routes/orders").default;
 const { publicRouter: menusPublicRouter } = require("./routes/menus");
+const { mediaRouter } = require("./routes/media");
 const whatsappConfig = require("./services/whatsapp/config");
 const { whatsappWebhookRouter } = require("./routes/whatsapp_webhook");
 
@@ -53,6 +54,7 @@ app.use("/api/contact", leadsRouter);
 app.use("/api/merchants", merchantsRouter);
 app.use("/api/orders", ordersRouter);
 app.use("/api/menus", menusPublicRouter);
+app.use("/media", mediaRouter);
 
 app.get("/r/:orderUuid", async (req, res) => {
   const orderUuid = req.params.orderUuid;

--- a/src/server/lib/s3.ts
+++ b/src/server/lib/s3.ts
@@ -7,6 +7,8 @@ export interface S3Config {
   client: S3Client | null;
 }
 
+export const MEDIA_PATH_PREFIX = '/media/';
+
 function env(name: string, fallback = ''): string {
   return process.env[name] || fallback;
 }
@@ -24,24 +26,77 @@ export function getS3Config(): S3Config {
 
   const endpointUrl = endpoint.replace(/\/$/, '');
   const publicBaseUrl = (env('S3_PUBLIC_URL') || `${endpointUrl}/${bucket}`).replace(/\/$/, '');
+  const forcePathStyle = env('S3_FORCE_PATH_STYLE') === 'true';
 
   const client = new S3Client({
     region,
     endpoint: endpointUrl,
-    forcePathStyle: true,
+    forcePathStyle,
     credentials: { accessKeyId, secretAccessKey },
   });
 
   return { enabled: true, bucket, publicBaseUrl, client };
 }
 
-export function publicUrlForKey(config: S3Config, key: string): string {
-  return `${config.publicBaseUrl}/${key.replace(/^\//, '')}`;
+/** Stable app URL for a stored object key (served via GET /media/*). */
+export function publicUrlForKey(_config: S3Config, key: string): string {
+  return `${MEDIA_PATH_PREFIX}${key.replace(/^\//, '')}`;
 }
 
 export function keyFromPublicUrl(config: S3Config, url: string | null | undefined): string | null {
   if (!url) return null;
+  if (url.startsWith(MEDIA_PATH_PREFIX)) {
+    return url.slice(MEDIA_PATH_PREFIX.length);
+  }
   const prefix = `${config.publicBaseUrl}/`;
   if (url.startsWith(prefix)) return url.slice(prefix.length);
   return null;
+}
+
+/** Parse object key from any stored image_url (proxy path, path-style, or virtual-hosted S3 URL). */
+export function keyFromStoredImageUrl(
+  url: string | null | undefined,
+  config?: S3Config
+): string | null {
+  if (!url) return null;
+
+  if (url.startsWith(MEDIA_PATH_PREFIX)) {
+    return url.slice(MEDIA_PATH_PREFIX.length);
+  }
+
+  const cfg = config?.enabled ? config : getS3Config();
+  if (cfg.publicBaseUrl && url.startsWith(`${cfg.publicBaseUrl}/`)) {
+    return url.slice(cfg.publicBaseUrl.length + 1);
+  }
+
+  if (cfg.bucket) {
+    const virtualHostedPrefix = `https://${cfg.bucket}.`;
+    if (url.startsWith(virtualHostedPrefix)) {
+      try {
+        return new URL(url).pathname.replace(/^\//, '');
+      } catch {
+        // fall through
+      }
+    }
+  }
+
+  const menuItemsIdx = url.indexOf('menu-items/');
+  if (menuItemsIdx >= 0) {
+    return url.slice(menuItemsIdx).split('?')[0];
+  }
+
+  return null;
+}
+
+/** Normalize stored image_url for API responses (rewrites legacy direct S3 URLs to /media/*). */
+export function normalizeMenuItemImageUrl(url: string | null | undefined): string | null {
+  if (!url) return null;
+  if (url.startsWith(MEDIA_PATH_PREFIX)) return url;
+
+  const key = keyFromStoredImageUrl(url, getS3Config());
+  if (key) {
+    return publicUrlForKey(getS3Config(), key);
+  }
+
+  return url;
 }

--- a/src/server/models/menus.ts
+++ b/src/server/models/menus.ts
@@ -1,4 +1,5 @@
 import db from './db';
+import { normalizeMenuItemImageUrl } from '../lib/s3';
 
 const T = () => db('menus');
 const JunctionT = () => db('menu_menu_items');
@@ -155,7 +156,7 @@ class Menus {
           name: r.name,
           description: r.description,
           price_cents: r.price_cents,
-          image_url: r.image_url,
+          image_url: normalizeMenuItemImageUrl(r.image_url),
           category_id: r.category_id,
           category_name: r.category_name,
           modifiers: [],

--- a/src/server/routes/media.ts
+++ b/src/server/routes/media.ts
@@ -1,0 +1,53 @@
+import { Router } from 'express';
+import { GetObjectCommand } from '@aws-sdk/client-s3';
+import { getS3Config, keyFromStoredImageUrl } from '../lib/s3';
+
+const router = Router();
+
+function isSafeObjectKey(key: string): boolean {
+  return (
+    key.startsWith('menu-items/') &&
+    !key.includes('..') &&
+    !key.includes('\\')
+  );
+}
+
+router.get('/{*splat}', async (req, res) => {
+  const config = getS3Config();
+  if (!config.enabled || !config.client) {
+    return res.status(503).json({ error: 'Object storage is not configured' });
+  }
+
+  const rawKey = req.params.splat;
+  const key = Array.isArray(rawKey) ? rawKey.join('/') : String(rawKey || '');
+  if (!key || !isSafeObjectKey(key)) {
+    return res.status(404).json({ error: 'Not found' });
+  }
+
+  try {
+    const object = await config.client.send(
+      new GetObjectCommand({ Bucket: config.bucket, Key: key })
+    );
+
+    if (object.ContentType) {
+      res.set('Content-Type', object.ContentType);
+    }
+    res.set('Cache-Control', 'public, max-age=86400');
+
+    const body = object.Body;
+    if (!body || typeof (body as NodeJS.ReadableStream).pipe !== 'function') {
+      return res.status(404).json({ error: 'Not found' });
+    }
+
+    (body as NodeJS.ReadableStream).pipe(res);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (/NoSuchKey|NotFound|404/i.test(message)) {
+      return res.status(404).json({ error: 'Not found' });
+    }
+    console.error('GET /media failed:', err);
+    res.status(500).json({ error: 'Failed to load image' });
+  }
+});
+
+export { router as mediaRouter };

--- a/src/server/routes/merchants.js
+++ b/src/server/routes/merchants.js
@@ -10,6 +10,7 @@ const {getNextStatus, canCancel, canRefund, Status} = require('../../shared/orde
 const { adminRouter: menusRouter } = require('./menus');
 const { categoriesRouter } = require('./menu_categories');
 const { subscribeMerchantOrders } = require('../services/order_events');
+const { normalizeMenuItemImageUrl } = require('../lib/s3');
 const {
     createMenuItemImagePresign,
     completeMenuItemImageUpload,
@@ -184,6 +185,14 @@ router.get('/:merchantId/menu', async (req, res) => {
 
 // ─── Menu Items CRUD ───
 
+function formatMenuItemResponse(item, modifiers = []) {
+    return {
+        ...item,
+        image_url: normalizeMenuItemImageUrl(item.image_url),
+        modifiers,
+    };
+}
+
 router.get('/:merchantId/menu-items', async (req, res) => {
     const merchantId = parseInt(req.params.merchantId, 10);
     if (isNaN(merchantId)) return res.sendStatus(400);
@@ -191,7 +200,7 @@ router.get('/:merchantId/menu-items', async (req, res) => {
     const itemsWithModifiers = await Promise.all(
         items.map(async (item) => {
             const modifiers = await Modifiers.getModifiersForMenuItem(item.id);
-            return { ...item, modifiers };
+            return formatMenuItemResponse(item, modifiers);
         })
     );
     res.json({ menuItems: itemsWithModifiers });
@@ -235,7 +244,7 @@ router.post('/:merchantId/menu-items', async (req, res) => {
             await Modifiers.setModifiersForMenuItem(item.id, modifierIds);
         }
         const modifiers = await Modifiers.getModifiersForMenuItem(item.id);
-        res.status(201).json({ menuItem: { ...item, modifiers } });
+        res.status(201).json({ menuItem: formatMenuItemResponse(item, modifiers) });
     } catch (err) {
         console.error('POST menu-items failed:', err);
         res.status(500).json({ error: err.message || 'Failed to create menu item' });
@@ -249,7 +258,7 @@ router.get('/:merchantId/menu-items/:menuItemId', async (req, res) => {
     const item = await MenuItems.getById(menuItemId);
     if (!item || item.merchant_id !== merchantId) return res.status(404).json({ error: 'Menu item not found' });
     const modifiers = await Modifiers.getModifiersForMenuItem(menuItemId);
-    res.json({ menuItem: { ...item, modifiers } });
+    res.json({ menuItem: formatMenuItemResponse(item, modifiers) });
 });
 
 // PUT and PATCH both support partial updates (REST: PUT = replace, PATCH = partial; we accept both for flexibility)
@@ -274,7 +283,7 @@ async function updateMenuItemHandler(req, res) {
     }
     const updated = await MenuItems.getById(menuItemId);
     const modifiers = await Modifiers.getModifiersForMenuItem(menuItemId);
-    res.json({ menuItem: { ...updated, modifiers } });
+    res.json({ menuItem: formatMenuItemResponse(updated, modifiers) });
 }
 
 router.put('/:merchantId/menu-items/:menuItemId', updateMenuItemHandler);

--- a/src/server/services/menu_item_images.ts
+++ b/src/server/services/menu_item_images.ts
@@ -7,7 +7,7 @@ import {
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import crypto from 'crypto';
 import sharp from 'sharp';
-import { getS3Config, keyFromPublicUrl, publicUrlForKey } from '../lib/s3';
+import { getS3Config, keyFromStoredImageUrl, publicUrlForKey } from '../lib/s3';
 import MenuItems from '../models/menu_items';
 
 const MAX_BYTES = 2 * 1024 * 1024;
@@ -150,7 +150,7 @@ export async function completeMenuItemImageUpload(params: {
   }
 
   const publicUrl = publicUrlForKey(config, finalKey);
-  const oldKey = keyFromPublicUrl(config, item.image_url);
+  const oldKey = keyFromStoredImageUrl(item.image_url, config);
   if (oldKey && oldKey !== finalKey) {
     await deleteObjectKey(oldKey);
   }
@@ -169,7 +169,7 @@ export async function deleteMenuItemImage(menuItemId: number) {
     throw err;
   }
 
-  const oldKey = keyFromPublicUrl(config, item.image_url);
+  const oldKey = keyFromStoredImageUrl(item.image_url, config);
   if (oldKey) await deleteObjectKey(oldKey);
   await MenuItems.update(menuItemId, { image_url: null });
   return { ok: true };
@@ -178,7 +178,7 @@ export async function deleteMenuItemImage(menuItemId: number) {
 export async function deleteMenuItemImageByUrl(imageUrl: string | null | undefined) {
   const config = getS3Config();
   if (!config.enabled || !imageUrl) return;
-  const key = keyFromPublicUrl(config, imageUrl);
+  const key = keyFromStoredImageUrl(imageUrl, config);
   if (key) await deleteObjectKey(key);
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Menu item images were saved with direct bucket URLs like:

`https://t3.storageapi.dev/pos-asset-store-fqilbdnyd/menu-items/mc_n1c0ffee/404/....webp`

Railway Object Storage buckets are **private** — those URLs return **403 Forbidden**, so thumbnails never load in the merchant menu list or online ordering.

The object key path (`menu-items/mc_n1c0ffee/404/...`) is correct; only the public URL strategy was wrong.

## Solution

- Serve images through the app at **`GET /media/menu-items/...`** (streams from S3 with server credentials)
- Save and return **`/media/...`** URLs instead of direct bucket URLs
- **Rewrite legacy** direct S3 URLs in API responses so existing uploads work without DB migration
- Default S3 client to **virtual-hosted style** (`S3_FORCE_PATH_STYLE=true` only when bucket credentials require it)

## After deploy

Existing menu items with old S3 URLs will automatically show as `/media/...` in the list. Re-upload is not required unless the object was never successfully stored in the bucket.

No `S3_PUBLIC_URL` needed — images always go through the app.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a40c83aa-4442-409d-86c8-ee5fd50c58b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a40c83aa-4442-409d-86c8-ee5fd50c58b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

