### PR TITLE
Optimize menu items list for 768px tablets

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqc-nodejs-demo",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "private": true,
   "main": "src/server/index.js",
   "scripts": {

--- a/src/client/css/pages/MerchantMenuItems.css
+++ b/src/client/css/pages/MerchantMenuItems.css
@@ -428,3 +428,171 @@
   flex: 1;
   min-width: 100px;
 }
+
+/* ===== Menu items list (Polaris IndexTable) ===== */
+
+.MenuItemsList__thumb {
+  width: 40px;
+  height: 40px;
+  border-radius: 8px;
+  overflow: hidden;
+  background: #f1f2f3;
+  flex-shrink: 0;
+}
+
+.MenuItemsList__thumbImg {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.MenuItemsList__thumbPlaceholder {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #8c9196;
+  font-size: 12px;
+}
+
+.MenuItemsList__name,
+.MenuItemsList__description,
+.MenuItemsList__modifiers,
+.MenuItemsList__price {
+  margin: 0;
+}
+
+.MenuItemsList__description {
+  color: #616161;
+  word-break: break-word;
+}
+
+.MenuItemsList__modifiers {
+  color: #616161;
+}
+
+.MenuItemsList__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 8px;
+  align-items: center;
+}
+
+/* Tablet (~768px): fit full table without horizontal scroll */
+@media (min-width: 768px) and (max-width: 1024px) {
+  .Polaris-Page:has(.MenuItemsList) {
+    max-width: 100%;
+  }
+
+  .Polaris-Page:has(.MenuItemsList) .Polaris-Page__Content {
+    padding-inline: 12px;
+  }
+
+  .MenuItemsList .Polaris-IndexTable-ScrollContainer {
+    overflow-x: visible;
+  }
+
+  .MenuItemsList .Polaris-IndexTable__Table {
+    table-layout: fixed;
+    width: 100%;
+  }
+
+  .MenuItemsList .Polaris-IndexTable__TableHeading:nth-child(1),
+  .MenuItemsList .Polaris-IndexTable__TableCell:nth-child(1) {
+    width: 44px;
+  }
+
+  .MenuItemsList .Polaris-IndexTable__TableHeading:nth-child(2),
+  .MenuItemsList .Polaris-IndexTable__TableCell:nth-child(2) {
+    width: 14%;
+  }
+
+  .MenuItemsList .Polaris-IndexTable__TableHeading:nth-child(3),
+  .MenuItemsList .Polaris-IndexTable__TableCell:nth-child(3) {
+    width: 24%;
+  }
+
+  .MenuItemsList .Polaris-IndexTable__TableHeading:nth-child(4),
+  .MenuItemsList .Polaris-IndexTable__TableCell:nth-child(4) {
+    width: 9%;
+  }
+
+  .MenuItemsList .Polaris-IndexTable__TableHeading:nth-child(5),
+  .MenuItemsList .Polaris-IndexTable__TableCell:nth-child(5) {
+    width: 17%;
+  }
+
+  .MenuItemsList .Polaris-IndexTable__TableHeading:nth-child(6),
+  .MenuItemsList .Polaris-IndexTable__TableCell:nth-child(6) {
+    width: 8%;
+  }
+
+  .MenuItemsList .Polaris-IndexTable__TableHeading:nth-child(7),
+  .MenuItemsList .Polaris-IndexTable__TableCell:nth-child(7) {
+    width: 14%;
+  }
+
+  .MenuItemsList .Polaris-IndexTable__TableCell,
+  .MenuItemsList .Polaris-IndexTable__TableHeading {
+    padding-inline: 6px;
+  }
+
+  .MenuItemsList .Polaris-IndexTable__ColumnHeaderText {
+    font-size: 0.75rem;
+  }
+
+  .MenuItemsList__thumb {
+    width: 36px;
+    height: 36px;
+  }
+
+  .MenuItemsList__name {
+    display: block;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: 0.875rem;
+  }
+
+  .MenuItemsList__description {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    overflow: hidden;
+    font-size: 0.8125rem;
+    line-height: 1.35;
+  }
+
+  .MenuItemsList__modifiers {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 1;
+    overflow: hidden;
+    font-size: 0.8125rem;
+    line-height: 1.35;
+  }
+
+  .MenuItemsList__price {
+    font-size: 0.875rem;
+    white-space: nowrap;
+  }
+
+  .MenuItemsList__actions {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0;
+  }
+}
+
+/* All viewports: clamp long descriptions to two lines */
+@media (min-width: 1025px) {
+  .MenuItemsList__description {
+    display: -webkit-box;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    overflow: hidden;
+    max-width: 36rem;
+  }
+}

--- a/src/client/js/pages/MerchantMenuItems.tsx
+++ b/src/client/js/pages/MerchantMenuItems.tsx
@@ -29,6 +29,7 @@ import {
   uploadMenuItemImage,
   validateMenuItemImageFile,
 } from '../lib/menuItemImageUpload';
+import '../../css/pages/MerchantMenuItems.css';
 
 export default function MerchantMenuItems(props: any) {
   const { t } = useTranslation();
@@ -148,42 +149,48 @@ function MenuItemsList({
   const rowMarkup = menuItems.map((item: any, index: number) => (
     <IndexTable.Row id={String(item.id)} key={item.id} position={index}>
       <IndexTable.Cell>
-        <div style={{ width: 40, height: 40, borderRadius: 8, overflow: 'hidden', background: '#f1f2f3' }}>
+        <div className="MenuItemsList__thumb">
           {item.image_url ? (
             <img
               src={item.image_url}
               alt=""
-              style={{ width: '100%', height: '100%', objectFit: 'cover' }}
+              className="MenuItemsList__thumbImg"
             />
           ) : (
-            <div style={{ width: '100%', height: '100%', display: 'flex', alignItems: 'center', justifyContent: 'center', color: '#8c9196', fontSize: 12 }}>
-              —
-            </div>
+            <div className="MenuItemsList__thumbPlaceholder">—</div>
           )}
         </div>
       </IndexTable.Cell>
       <IndexTable.Cell>
         <Text variant="bodyMd" fontWeight="semibold" as="span">
-          {item.name}
+          <span className="MenuItemsList__name">{item.name}</span>
         </Text>
       </IndexTable.Cell>
       <IndexTable.Cell>
-        {(item.description || '').slice(0, 50)}
-        {(item.description || '').length > 50 ? '…' : ''}
+        <p className="MenuItemsList__description">{item.description || '—'}</p>
       </IndexTable.Cell>
-      <IndexTable.Cell>${((item.price_cents || 0) / 100).toFixed(2)}</IndexTable.Cell>
       <IndexTable.Cell>
-        {item.modifiers?.length ? item.modifiers.map((m: any) => m.name).join(', ') : '—'}
+        <span className="MenuItemsList__price">${((item.price_cents || 0) / 100).toFixed(2)}</span>
+      </IndexTable.Cell>
+      <IndexTable.Cell>
+        <p className="MenuItemsList__modifiers">
+          {item.modifiers?.length ? item.modifiers.map((m: any) => m.name).join(', ') : '—'}
+        </p>
       </IndexTable.Cell>
       <IndexTable.Cell>{item.is_active !== false ? t('common.yes') : t('common.no')}</IndexTable.Cell>
       <IndexTable.Cell>
-        <Button plain onClick={() => history.push(merchantDashboardPath(merchantHashId, `menuitems/${item.id}/edit`))}>
-          {t('common.edit')}
-        </Button>
-        {' · '}
-        <Button plain destructive onClick={() => handleDelete(item.id)}>
-          {t('common.delete')}
-        </Button>
+        <div className="MenuItemsList__actions">
+          <Button
+            plain
+            size="slim"
+            onClick={() => history.push(merchantDashboardPath(merchantHashId, `menuitems/${item.id}/edit`))}
+          >
+            {t('common.edit')}
+          </Button>
+          <Button plain size="slim" destructive onClick={() => handleDelete(item.id)}>
+            {t('common.delete')}
+          </Button>
+        </div>
       </IndexTable.Cell>
     </IndexTable.Row>
   ));
@@ -207,6 +214,7 @@ function MenuItemsList({
         )}
 
         <Layout.Section>
+          <div className="MenuItemsList">
           {menuItems.length === 0 ? (
             <Card sectioned>
               <EmptyState
@@ -218,6 +226,7 @@ function MenuItemsList({
           ) : (
             <Card>
               <IndexTable
+                condensed
                 resourceName={{ singular: 'menu item', plural: 'menu items' }}
                 itemCount={menuItems.length}
                 headings={[
@@ -235,6 +244,7 @@ function MenuItemsList({
               </IndexTable>
             </Card>
           )}
+          </div>
         </Layout.Section>
       </Layout>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Optimizes the menu items list (`/md/:hashId/menuitems`) for **768px tablets** so the full IndexTable fits on screen without horizontal scrolling.

## Changes

- **Condensed** Polaris `IndexTable` with fixed column widths at 768–1024px
- **Description** shows up to **2 lines** (CSS line-clamp) instead of a 50-character cut
- **Modifiers** clamp to 1 line; **name** ellipsizes on one line
- **Edit / Delete** use slim buttons, stacked vertically on tablet to save width
- Reduced page padding and cell padding on tablet

## Verify

Open `/md/mc_n1c0ffee/menuitems` at 768px width (DevTools iPad) — all columns visible, no horizontal scroll.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a40c83aa-4442-409d-86c8-ee5fd50c58b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a40c83aa-4442-409d-86c8-ee5fd50c58b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

