### PR TITLE
Remove KDS date selector and fix filter alignment on desktop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqc-nodejs-demo",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "private": true,
   "main": "src/server/index.js",
   "scripts": {

--- a/src/client/css/pages/MerchantRoutes.css
+++ b/src/client/css/pages/MerchantRoutes.css
@@ -150,9 +150,22 @@
 @media (min-width: 900px) {
   .OrdersGrid {
     display: grid;
-    grid-template-rows: auto 1fr;
+    grid-template-rows: auto auto 1fr;
     grid-template-columns: 1fr;
+    gap: 8px;
+    padding: 8px 12px 12px;
   }
+
+  .OrdersGrid__header {
+    padding: 4px 4px 0;
+  }
+
+  .OrdersGrid__filters {
+    align-self: start;
+    padding: 0 4px 4px;
+    justify-content: flex-start;
+  }
+
   .OrdersGrid__cards {
     grid-template-columns: repeat(4, 1fr);
     grid-template-rows: repeat(2, 1fr);
@@ -766,47 +779,16 @@
   font-size: 1rem;
 }
 
-/* ===== Filters: Date Row & Status Pills ===== */
+/* ===== Filters: Status Pills ===== */
 
 .OrdersGrid__filters {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-start;
   gap: 12px;
-  padding: 8px 4px 4px;
+  padding: 4px 4px 0;
   flex-shrink: 0;
-}
-
-.OrdersGrid__date-row {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-}
-
-.OrdersGrid__date-input {
-  background: #1a1a1a;
-  border: 2px solid #333;
-  border-radius: 10px;
-  color: #fff;
-  padding: 10px 14px;
-  font-size: 1rem;
-  font-weight: 600;
-  font-family: inherit;
-  min-height: 44px;
-  -webkit-appearance: none;
-}
-
-.OrdersGrid__date-input:focus {
-  outline: none;
-  border-color: #00E5FF;
-}
-
-.OrdersGrid__order-count {
-  color: #888;
-  font-size: 0.95rem;
-  font-weight: 600;
-  white-space: nowrap;
 }
 
 .OrdersGrid__filter-dropdown {
@@ -956,20 +938,14 @@
 
 /* ===== Light Theme Overrides ===== */
 
-.Merchant--theme-light .OrdersGrid__date-input,
 .Merchant--theme-light .OrdersGrid__filter-dropdown {
   background: #fff;
   border-color: #ddd;
   color: #1a1a1a;
 }
 
-.Merchant--theme-light .OrdersGrid__date-input:focus,
 .Merchant--theme-light .OrdersGrid__filter-dropdown:focus {
   border-color: #00B8D4;
-}
-
-.Merchant--theme-light .OrdersGrid__order-count {
-  color: #666;
 }
 
 .Merchant--theme-light .OrdersGrid__pill {

--- a/src/client/js/pages/MerchantRoutes.tsx
+++ b/src/client/js/pages/MerchantRoutes.tsx
@@ -116,7 +116,6 @@ function todayISO() {
 function OrdersListPage({ merchantId, merchantName, merchantHashId, onSelectOrder, t }: { merchantId: number; merchantName: string; merchantHashId: string; onSelectOrder: (id: number) => void; t: (key: string) => string }) {
   const [orders, setOrders] = useState<any>(null);
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('active');
-  const [dateFilter, setDateFilter] = useState<string>(() => todayISO());
   const [highlightedIds, setHighlightedIds] = useState<Set<number>>(() => new Set());
   const highlightTimers = useRef<Map<number, ReturnType<typeof setTimeout>>>(new Map());
   const isMobile = useIsMobile();
@@ -124,9 +123,9 @@ function OrdersListPage({ merchantId, merchantName, merchantHashId, onSelectOrde
 
   const loadOrders = useCallback(() => {
     const params = new URLSearchParams();
-    params.set('date', dateFilter);
+    params.set('date', todayISO());
     return fetchApi(`/api/merchants/${merchantId}/orders?${params}`).then(setOrders);
-  }, [merchantId, dateFilter]);
+  }, [merchantId]);
 
   useEffect(() => { loadOrders(); }, [loadOrders]);
 
@@ -160,7 +159,7 @@ function OrdersListPage({ merchantId, merchantName, merchantHashId, onSelectOrde
 
   const orderList = orders ? Object.values(orders) as any[] : [];
 
-  const { awaitingPreparing, ready, canceledRefunded, orderCountToday } = useMemo(() => {
+  const { awaitingPreparing, ready, canceledRefunded } = useMemo(() => {
     const sortFifo = (a: any, b: any) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
     const awaiting = orderList
       .filter((o: any) => AWAITING_PREPARING_STATUSES.includes(o.status))
@@ -173,7 +172,6 @@ function OrdersListPage({ merchantId, merchantName, merchantHashId, onSelectOrde
       awaitingPreparing: awaiting,
       ready: readyList,
       canceledRefunded: canceled,
-      orderCountToday: orderList.length,
     };
   }, [orderList]);
 
@@ -198,18 +196,6 @@ function OrdersListPage({ merchantId, merchantName, merchantHashId, onSelectOrde
         </div>
       </div>
       <div className="OrdersGrid__filters">
-        <div className="OrdersGrid__date-row">
-          <input
-            type="date"
-            className="OrdersGrid__date-input"
-            value={dateFilter}
-            onChange={(e) => setDateFilter(e.target.value)}
-            aria-label="Filter orders by date"
-          />
-          <span className="OrdersGrid__order-count">
-            {orderCountToday} order{orderCountToday !== 1 ? 's' : ''} today
-          </span>
-        </div>
         {isMobile ? (
           <select
             className="OrdersGrid__filter-dropdown"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Cleans up the merchant KDS order board layout.

## Changes

- **Removed** the date picker and "X orders today" row from the KDS screen
- Orders still load for **today only** (API `date=` param unchanged, not user-configurable)
- **Fixed desktop layout gap:** grid now uses `auto auto 1fr` rows so header, filters, and cards stack correctly at ≥900px (previously filters landed in the flexible middle row, creating empty space)

## Verify

Open `/md/mc_n1c0ffee` at desktop width — Active / Canceled pills should sit directly under the header with no large gap.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a40c83aa-4442-409d-86c8-ee5fd50c58b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a40c83aa-4442-409d-86c8-ee5fd50c58b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

