### PR TITLE
Add Supabase merchant authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,12 +8,10 @@
 # Supabase Auth — merchant dashboard sign-in
 # Browser-safe values for Vite:
 # VITE_SUPABASE_URL=https://your-project.supabase.co
-# VITE_SUPABASE_ANON_KEY=
-# Server-side token verification. SUPABASE_SERVICE_ROLE_KEY is preferred when available;
-# otherwise the server can use SUPABASE_ANON_KEY to call Supabase Auth.
+# VITE_SUPABASE_PUBLISHABLE_KEY=
+# Server-side token verification and admin user creation:
 # SUPABASE_URL=https://your-project.supabase.co
-# SUPABASE_ANON_KEY=
-# SUPABASE_SERVICE_ROLE_KEY=
+# SUPABASE_SECRET_KEY=
 # Secret for short-lived merchant order stream tokens.
 # MERCHANT_AUTH_STREAM_SECRET=change-me-to-a-random-string
 

--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,18 @@
 # Public URL for links in future WhatsApp templates (HTTPS in production)
 # PUBLIC_BASE_URL=https://your-domain.com
 
+# Supabase Auth — merchant dashboard sign-in
+# Browser-safe values for Vite:
+# VITE_SUPABASE_URL=https://your-project.supabase.co
+# VITE_SUPABASE_ANON_KEY=
+# Server-side token verification. SUPABASE_SERVICE_ROLE_KEY is preferred when available;
+# otherwise the server can use SUPABASE_ANON_KEY to call Supabase Auth.
+# SUPABASE_URL=https://your-project.supabase.co
+# SUPABASE_ANON_KEY=
+# SUPABASE_SERVICE_ROLE_KEY=
+# Secret for short-lived merchant order stream tokens.
+# MERCHANT_AUTH_STREAM_SECRET=change-me-to-a-random-string
+
 # WhatsApp Cloud API — Step 2 platform wiring
 # Set WHATSAPP_VERIFY_TOKEN to register the webhook in Meta App Dashboard
 WHATSAPP_VERIFY_TOKEN=change-me-to-a-random-string

--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,9 @@
 # Browser-safe values for Vite:
 # VITE_SUPABASE_URL=https://your-project.supabase.co
 # VITE_SUPABASE_PUBLISHABLE_KEY=
-# Server-side token verification and admin user creation:
+# Server-side token verification and admin user creation.
+# The server/scripts use VITE_SUPABASE_URL above; set SUPABASE_URL only if you need
+# a server-only override for the same project URL.
 # SUPABASE_URL=https://your-project.supabase.co
 # SUPABASE_SECRET_KEY=
 # Secret for short-lived merchant order stream tokens.

--- a/db/migrations/20260629000000_create_merchant_users.js
+++ b/db/migrations/20260629000000_create_merchant_users.js
@@ -1,0 +1,22 @@
+exports.up = async function (knex) {
+  await knex.schema.createTable('merchant_users', function (table) {
+    table.increments('id').primary();
+    table
+      .integer('merchant_id')
+      .unsigned()
+      .notNullable()
+      .references('id')
+      .inTable('merchants')
+      .onDelete('CASCADE');
+    table.string('supabase_user_id', 128).notNullable();
+    table.string('role', 32).notNullable().defaultTo('owner');
+    table.timestamp('created_at').notNullable().defaultTo(knex.fn.now());
+
+    table.unique(['merchant_id', 'supabase_user_id']);
+    table.index(['supabase_user_id']);
+  });
+};
+
+exports.down = async function (knex) {
+  await knex.schema.dropTableIfExists('merchant_users');
+};

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@aws-sdk/client-s3": "^3.1075.0",
     "@aws-sdk/s3-request-presigner": "^3.1075.0",
     "@shopify/polaris": "^10.50.1",
+    "@supabase/supabase-js": "^2.108.2",
     "camelcase-keys": "^6.2.2",
     "chai": "^4.5.0",
     "cookie-parser": "~1.4.7",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test": "DB_CLIENT=sqlite3 DB_FILENAME=test.db NODE_ENV=development mocha specs/**/* --exit",
     "test:pg": "NODE_ENV=development mocha specs/**/*",
     "create-merchant": "node scripts/create-merchant.js",
+    "link-merchant-user": "node scripts/link-merchant-user.js",
     "screenshots:merchant": "node scripts/capture-merchant-screenshots.js",
     "screenshots:i18n": "node scripts/capture-i18n-screenshots.js",
     "db:migrate": "knex migrate:latest --knexfile db/knexfile.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@shopify/polaris':
         specifier: ^10.50.1
         version: 10.50.1(react-dom@16.14.0(react@16.14.0))(react@16.14.0)
+      '@supabase/supabase-js':
+        specifier: ^2.108.2
+        version: 2.108.2
       camelcase-keys:
         specifier: ^6.2.2
         version: 6.2.2
@@ -1097,6 +1100,33 @@ packages:
     resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
     engines: {node: '>=14.0.0'}
 
+  '@supabase/auth-js@2.108.2':
+    resolution: {integrity: sha512-tNaQmBgodDZwgB40mRwVbxFy8IDYwjdpcZ0BYrWiwlULCSQoJj4QoG4zgJT7QRPXcqipefNOzvO/qAu4dF98ag==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/functions-js@2.108.2':
+    resolution: {integrity: sha512-RNUX8EiBy3iLwAX19jtRzLyePnl11/fHcgwDHLnpKcDSXt/5qBnh3LUwAtIjT21Q66QsmNUR2esrHziLCpNubw==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/phoenix@0.4.4':
+    resolution: {integrity: sha512-Gt0pqoXuIqX/8dvG0OKp/wMCobXNH3klNbUPBNyOfN0YA1IswrM3HyWFMOPk1Jy+BRaIyDPcFx4jLBwHNmlyfQ==}
+
+  '@supabase/postgrest-js@2.108.2':
+    resolution: {integrity: sha512-GQ28/Y8hk3CFmkb3kXH1h/AQx6JIYSQfO0CJMRVBcEKZoNy6C45cXAZ4fcJvRC5Id0cs6xnkUV0+c0rIocigsw==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/realtime-js@2.108.2':
+    resolution: {integrity: sha512-aAGxCSUemZvQIibnCdvNvgaKib28I4rfrNjKbQ9cG1uBLwUsI7hVpGXgEbypCCDhLjQlDTAiJlu7rgljYUT73g==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/storage-js@2.108.2':
+    resolution: {integrity: sha512-TVZPQxXGxY2+A6yTtm77zUHsh70lBhYUEaJL8RQC+BghcX/ygiMG/rmXrNVBce30/WAeNPa8FiG8HbqlGeV05g==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/supabase-js@2.108.2':
+    resolution: {integrity: sha512-hFhnPveb5JQg4a0QYicM0swT253YHMdfeRAl2BKHOlI5VAzuHxUGSr8RbwNLYNPauWOgQMS1H8sz8bvYlgwUfQ==}
+    engines: {node: '>=20.0.0'}
+
   '@tailwindcss/node@4.3.0':
     resolution: {integrity: sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==}
 
@@ -1965,6 +1995,10 @@ packages:
     peerDependenciesMeta:
       typescript:
         optional: true
+
+  iceberg-js@0.8.1:
+    resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
+    engines: {node: '>=20.0.0'}
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
@@ -3980,6 +4014,38 @@ snapshots:
       '@smithy/util-buffer-from': 2.2.0
       tslib: 2.8.1
 
+  '@supabase/auth-js@2.108.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/functions-js@2.108.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/phoenix@0.4.4': {}
+
+  '@supabase/postgrest-js@2.108.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/realtime-js@2.108.2':
+    dependencies:
+      '@supabase/phoenix': 0.4.4
+      tslib: 2.8.1
+
+  '@supabase/storage-js@2.108.2':
+    dependencies:
+      iceberg-js: 0.8.1
+      tslib: 2.8.1
+
+  '@supabase/supabase-js@2.108.2':
+    dependencies:
+      '@supabase/auth-js': 2.108.2
+      '@supabase/functions-js': 2.108.2
+      '@supabase/postgrest-js': 2.108.2
+      '@supabase/realtime-js': 2.108.2
+      '@supabase/storage-js': 2.108.2
+
   '@tailwindcss/node@4.3.0':
     dependencies:
       '@jridgewell/remapping': 2.3.5
@@ -4951,6 +5017,8 @@ snapshots:
       '@babel/runtime': 7.29.7
     optionalDependencies:
       typescript: 5.9.3
+
+  iceberg-js@0.8.1: {}
 
   iconv-lite@0.6.3:
     dependencies:

--- a/scripts/link-merchant-user.js
+++ b/scripts/link-merchant-user.js
@@ -81,18 +81,18 @@ function generateTemporaryPassword() {
 
 function requireSupabaseAdminConfig() {
   const url = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL;
-  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
-  if (!url || !serviceRoleKey) {
+  const secretKey = process.env.SUPABASE_SECRET_KEY;
+  if (!url || !secretKey) {
     throw new Error(
-      'SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY are required to create Supabase Auth users'
+      'SUPABASE_URL and SUPABASE_SECRET_KEY are required to create Supabase Auth users'
     );
   }
-  return { url, serviceRoleKey };
+  return { url, secretKey };
 }
 
 function createSupabaseAdminClient() {
-  const { url, serviceRoleKey } = requireSupabaseAdminConfig();
-  return createClient(url, serviceRoleKey, {
+  const { url, secretKey } = requireSupabaseAdminConfig();
+  return createClient(url, secretKey, {
     auth: {
       autoRefreshToken: false,
       persistSession: false,

--- a/scripts/link-merchant-user.js
+++ b/scripts/link-merchant-user.js
@@ -84,7 +84,7 @@ function requireSupabaseAdminConfig() {
   const secretKey = process.env.SUPABASE_SECRET_KEY;
   if (!url || !secretKey) {
     throw new Error(
-      'SUPABASE_URL and SUPABASE_SECRET_KEY are required to create Supabase Auth users'
+      'VITE_SUPABASE_URL (or SUPABASE_URL) and SUPABASE_SECRET_KEY are required to create Supabase Auth users'
     );
   }
   return { url, secretKey };
@@ -278,6 +278,7 @@ module.exports = {
   findSupabaseUserByEmail,
   linkMerchantUser,
   parseArgs,
+  requireSupabaseAdminConfig,
   resolveMerchant,
   run,
   usage,

--- a/scripts/link-merchant-user.js
+++ b/scripts/link-merchant-user.js
@@ -49,7 +49,9 @@ function parseArgs(argv = process.argv.slice(2)) {
 
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
-    if (arg === '--help' || arg === '-h') {
+    if (arg === '--') {
+      continue;
+    } else if (arg === '--help' || arg === '-h') {
       result.help = true;
     } else if (arg === '--password' && argv[i + 1]) {
       result.password = argv[++i];

--- a/scripts/link-merchant-user.js
+++ b/scripts/link-merchant-user.js
@@ -1,0 +1,282 @@
+#!/usr/bin/env node
+/**
+ * Admin script to create/link a Supabase Auth user to a merchant account.
+ *
+ * Usage:
+ *   pnpm run link-merchant-user <merchant-id|uuid|mc_hash> <email> [options]
+ *
+ * Options:
+ *   --password "temporary-password"  Password for newly created Supabase users.
+ *   --role owner|admin|staff         Role stored in merchant_users. Defaults to owner.
+ *   --no-email-confirm              Do not mark the Supabase user's email as confirmed.
+ *
+ * Examples:
+ *   pnpm run link-merchant-user mc_n1c0ffee owner@example.com
+ *   pnpm run link-merchant-user 1 owner@example.com --password "change-me-now"
+ */
+
+require('dotenv').config();
+const crypto = require('crypto');
+const knex = require('knex');
+const path = require('path');
+const { createClient } = require('@supabase/supabase-js');
+
+const knexfile = require(path.join(__dirname, '../db/knexfile.js'));
+const env = process.env.NODE_ENV || 'development';
+const config = knexfile[env] || knexfile.development;
+
+function usage() {
+  return [
+    'Usage: pnpm run link-merchant-user <merchant-id|uuid|mc_hash> <email> [options]',
+    '',
+    'Options:',
+    '  --password "temporary-password"  Password for newly created Supabase users.',
+    '  --role owner|admin|staff         Role stored in merchant_users. Defaults to owner.',
+    '  --no-email-confirm              Do not mark the Supabase user email as confirmed.',
+  ].join('\n');
+}
+
+function parseArgs(argv = process.argv.slice(2)) {
+  const result = {
+    merchantParam: null,
+    email: null,
+    password: null,
+    role: 'owner',
+    emailConfirm: true,
+    help: false,
+  };
+  const positional = [];
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === '--help' || arg === '-h') {
+      result.help = true;
+    } else if (arg === '--password' && argv[i + 1]) {
+      result.password = argv[++i];
+    } else if (arg === '--role' && argv[i + 1]) {
+      result.role = argv[++i];
+    } else if (arg === '--no-email-confirm') {
+      result.emailConfirm = false;
+    } else if (!arg.startsWith('-')) {
+      positional.push(arg);
+    } else {
+      throw new Error(`Unknown or incomplete option: ${arg}`);
+    }
+  }
+
+  result.merchantParam = positional[0] || null;
+  result.email = positional[1] || null;
+  return result;
+}
+
+function normalizeEmail(email) {
+  return String(email || '').trim().toLowerCase();
+}
+
+function generateTemporaryPassword() {
+  return crypto.randomBytes(18).toString('base64url');
+}
+
+function requireSupabaseAdminConfig() {
+  const url = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !serviceRoleKey) {
+    throw new Error(
+      'SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY are required to create Supabase Auth users'
+    );
+  }
+  return { url, serviceRoleKey };
+}
+
+function createSupabaseAdminClient() {
+  const { url, serviceRoleKey } = requireSupabaseAdminConfig();
+  return createClient(url, serviceRoleKey, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  });
+}
+
+async function findSupabaseUserByEmail(supabase, email) {
+  const target = normalizeEmail(email);
+  const perPage = 1000;
+  let page = 1;
+
+  while (true) {
+    const { data, error } = await supabase.auth.admin.listUsers({ page, perPage });
+    if (error) throw error;
+    const users = data?.users || [];
+    const match = users.find((user) => normalizeEmail(user.email) === target);
+    if (match) return match;
+    if (users.length < perPage) return null;
+    page += 1;
+  }
+}
+
+async function createOrFindSupabaseUser(
+  supabase,
+  email,
+  { password, emailConfirm = true } = {}
+) {
+  const normalizedEmail = normalizeEmail(email);
+  if (!normalizedEmail) throw new Error('Email is required');
+
+  const existing = await findSupabaseUserByEmail(supabase, normalizedEmail);
+  if (existing) {
+    return { user: existing, created: false, password: null };
+  }
+
+  const newPassword = password || generateTemporaryPassword();
+  const { data, error } = await supabase.auth.admin.createUser({
+    email: normalizedEmail,
+    password: newPassword,
+    email_confirm: emailConfirm,
+  });
+
+  if (error) {
+    const message = String(error.message || '');
+    if (/already|exists|registered/i.test(message)) {
+      const user = await findSupabaseUserByEmail(supabase, normalizedEmail);
+      if (user) return { user, created: false, password: null };
+    }
+    throw error;
+  }
+
+  if (!data?.user?.id) {
+    throw new Error('Supabase did not return a user id');
+  }
+
+  return { user: data.user, created: true, password: newPassword };
+}
+
+async function resolveMerchant(db, param) {
+  if (!param) return null;
+
+  if (/^\d+$/.test(param)) {
+    const merchant = await db('merchants').where('id', Number(param)).first();
+    if (merchant) return merchant;
+  }
+
+  const byHash = await db('merchants').where('hash_id', param).first();
+  if (byHash) return byHash;
+
+  return db('merchants').where('uuid', param).first();
+}
+
+async function linkMerchantUser(db, { merchantId, supabaseUserId, role }) {
+  const existing = await db('merchant_users')
+    .where({
+      merchant_id: merchantId,
+      supabase_user_id: supabaseUserId,
+    })
+    .first();
+
+  if (existing) {
+    if (existing.role !== role) {
+      await db('merchant_users').where('id', existing.id).update({ role });
+      return { created: false, updated: true, id: existing.id };
+    }
+    return { created: false, updated: false, id: existing.id };
+  }
+
+  const result = await db('merchant_users')
+    .insert({
+      merchant_id: merchantId,
+      supabase_user_id: supabaseUserId,
+      role,
+    })
+    .returning('id');
+  const inserted = Array.isArray(result) ? result[0] : result;
+  const id = typeof inserted === 'object' && inserted !== null ? inserted.id : inserted;
+  return { created: true, updated: false, id };
+}
+
+async function run(argv = process.argv.slice(2), deps = {}) {
+  const args = parseArgs(argv);
+  if (args.help) {
+    return { help: true };
+  }
+
+  if (!args.merchantParam || !args.email) {
+    throw new Error(`Merchant identifier and email are required\n\n${usage()}`);
+  }
+
+  const db = deps.db || knex(config);
+  const supabase = deps.supabase || createSupabaseAdminClient();
+  let shouldDestroy = !deps.db;
+
+  try {
+    const merchant = await resolveMerchant(db, args.merchantParam);
+    if (!merchant) {
+      throw new Error(`Merchant '${args.merchantParam}' not found`);
+    }
+
+    const userResult = await createOrFindSupabaseUser(supabase, args.email, {
+      password: args.password,
+      emailConfirm: args.emailConfirm,
+    });
+    const linkResult = await linkMerchantUser(db, {
+      merchantId: merchant.id,
+      supabaseUserId: userResult.user.id,
+      role: args.role,
+    });
+
+    return {
+      merchant,
+      supabaseUser: userResult.user,
+      supabaseUserCreated: userResult.created,
+      temporaryPassword: userResult.password,
+      link: linkResult,
+      role: args.role,
+    };
+  } finally {
+    if (shouldDestroy) {
+      await db.destroy();
+    }
+  }
+}
+
+async function main() {
+  try {
+    const result = await run();
+    if (result.help) {
+      console.log(usage());
+      return;
+    }
+
+    console.log('Merchant user linked successfully.');
+    console.log('');
+    console.log('  Merchant ID:       ', result.merchant.id);
+    console.log('  Merchant Code:     ', result.merchant.hash_id);
+    console.log('  Business Name:     ', result.merchant.business_name);
+    console.log('  Supabase User ID:  ', result.supabaseUser.id);
+    console.log('  Supabase Email:    ', result.supabaseUser.email);
+    console.log('  Supabase Created:  ', result.supabaseUserCreated ? 'yes' : 'no');
+    console.log('  Link Created:      ', result.link.created ? 'yes' : 'no');
+    console.log('  Link Updated:      ', result.link.updated ? 'yes' : 'no');
+    console.log('  Role:              ', result.role);
+    if (result.temporaryPassword) {
+      console.log('');
+      console.log('  Temporary Password:', result.temporaryPassword);
+      console.log('  Share this securely and ask the merchant to change it after signing in.');
+    }
+  } catch (err) {
+    console.error('Error:', err.message);
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  createOrFindSupabaseUser,
+  findSupabaseUserByEmail,
+  linkMerchantUser,
+  parseArgs,
+  resolveMerchant,
+  run,
+  usage,
+};

--- a/specs/routes/merchantAuth.spec.ts
+++ b/specs/routes/merchantAuth.spec.ts
@@ -91,6 +91,15 @@ describe('merchant Supabase auth', () => {
     expect(res.body.menuItems).to.deep.equal([]);
   });
 
+  it('allows linked users to preflight merchant dashboard authorization', async () => {
+    const res = await request(app)
+      .get(`/api/merchants/${merchantId}/authz`)
+      .set('Authorization', 'Bearer token-user-1')
+      .expect(200);
+
+    expect(res.body).to.deep.equal({ ok: true });
+  });
+
   it('rejects access to merchants the user is not linked to', async () => {
     await request(app)
       .get(`/api/merchants/${otherMerchantId}/menu-items`)

--- a/specs/routes/merchantAuth.spec.ts
+++ b/specs/routes/merchantAuth.spec.ts
@@ -1,0 +1,114 @@
+import { expect } from 'chai';
+import path from 'path';
+import request from 'supertest';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const db = require('../../src/server/models/db');
+const app = require('../../src/server/index');
+const {
+  setSupabaseUserResolverForTest,
+  verifyMerchantStreamToken,
+} = require('../../src/server/middleware/merchantAuth');
+
+const migrationsDir = path.resolve(__dirname, '../../db/migrations');
+
+let merchantId: number;
+let otherMerchantId: number;
+
+async function resetAll() {
+  await db('merchant_users').del();
+  await db('menu_items').del();
+  await db('merchants').del();
+  for (const t of ['merchant_users', 'menu_items', 'merchants']) {
+    await db.raw(`DELETE FROM sqlite_sequence WHERE name = '${t}'`);
+  }
+}
+
+describe('merchant Supabase auth', () => {
+  before(async () => {
+    process.env.MERCHANT_AUTH_STREAM_SECRET = 'test-stream-secret';
+    setSupabaseUserResolverForTest(async (token: string) => {
+      if (token === 'token-user-1') return { id: 'user-1', email: 'owner@example.com' };
+      if (token === 'token-user-2') return { id: 'user-2', email: 'other@example.com' };
+      return null;
+    });
+
+    await db.raw('PRAGMA foreign_keys = ON');
+    await db.migrate.latest({ directory: migrationsDir, tableName: 'knex_migrations' });
+    await resetAll();
+
+    [merchantId] = await db('merchants').insert({
+      business_name: 'Authenticated Cafe',
+      type: 'cafe',
+      uuid: 'auth0001-0001-0001-0001-000000000001',
+      hash_id: 'mc_authcafe',
+    });
+    [otherMerchantId] = await db('merchants').insert({
+      business_name: 'Other Cafe',
+      type: 'cafe',
+      uuid: 'auth0002-0002-0002-0002-000000000002',
+      hash_id: 'mc_othercafe',
+    });
+    await db('merchant_users').insert({
+      merchant_id: merchantId,
+      supabase_user_id: 'user-1',
+      role: 'owner',
+    });
+  });
+
+  after(() => {
+    setSupabaseUserResolverForTest(null);
+  });
+
+  it('keeps merchant hash lookup public', async () => {
+    const res = await request(app)
+      .get('/api/merchants/mc_authcafe')
+      .expect(200);
+
+    expect(res.body.id).to.equal(merchantId);
+  });
+
+  it('rejects merchant admin APIs without a bearer token', async () => {
+    await request(app)
+      .get(`/api/merchants/${merchantId}/menu-items`)
+      .expect(401);
+  });
+
+  it('rejects invalid bearer tokens', async () => {
+    await request(app)
+      .get(`/api/merchants/${merchantId}/menu-items`)
+      .set('Authorization', 'Bearer not-valid')
+      .expect(401);
+  });
+
+  it('allows a linked Supabase user to access their merchant admin APIs', async () => {
+    const res = await request(app)
+      .get(`/api/merchants/${merchantId}/menu-items`)
+      .set('Authorization', 'Bearer token-user-1')
+      .expect(200);
+
+    expect(res.body.menuItems).to.deep.equal([]);
+  });
+
+  it('rejects access to merchants the user is not linked to', async () => {
+    await request(app)
+      .get(`/api/merchants/${otherMerchantId}/menu-items`)
+      .set('Authorization', 'Bearer token-user-1')
+      .expect(403);
+  });
+
+  it('issues scoped stream tokens for linked users', async () => {
+    const res = await request(app)
+      .post(`/api/merchants/${merchantId}/orders/stream-token`)
+      .set('Authorization', 'Bearer token-user-1')
+      .send({})
+      .expect(200);
+
+    const payload = verifyMerchantStreamToken(res.body.token);
+    expect(payload).to.include({
+      merchantId,
+      supabaseUserId: 'user-1',
+    });
+  });
+});

--- a/specs/scripts/linkMerchantUser.spec.ts
+++ b/specs/scripts/linkMerchantUser.spec.ts
@@ -7,6 +7,7 @@ const {
   createOrFindSupabaseUser,
   linkMerchantUser,
   parseArgs,
+  requireSupabaseAdminConfig,
   resolveMerchant,
 } = require('../../scripts/link-merchant-user');
 
@@ -81,6 +82,30 @@ describe('link-merchant-user script helpers', () => {
       role: 'admin',
       emailConfirm: false,
     });
+  });
+
+  it('uses VITE_SUPABASE_URL as the admin script URL fallback', () => {
+    const oldSupabaseUrl = process.env.SUPABASE_URL;
+    const oldViteSupabaseUrl = process.env.VITE_SUPABASE_URL;
+    const oldSecretKey = process.env.SUPABASE_SECRET_KEY;
+
+    delete process.env.SUPABASE_URL;
+    process.env.VITE_SUPABASE_URL = 'https://project-ref.supabase.co';
+    process.env.SUPABASE_SECRET_KEY = 'sb_secret_test';
+
+    try {
+      expect(requireSupabaseAdminConfig()).to.deep.equal({
+        url: 'https://project-ref.supabase.co',
+        secretKey: 'sb_secret_test',
+      });
+    } finally {
+      if (oldSupabaseUrl === undefined) delete process.env.SUPABASE_URL;
+      else process.env.SUPABASE_URL = oldSupabaseUrl;
+      if (oldViteSupabaseUrl === undefined) delete process.env.VITE_SUPABASE_URL;
+      else process.env.VITE_SUPABASE_URL = oldViteSupabaseUrl;
+      if (oldSecretKey === undefined) delete process.env.SUPABASE_SECRET_KEY;
+      else process.env.SUPABASE_SECRET_KEY = oldSecretKey;
+    }
   });
 
   it('creates a Supabase user when email is new', async () => {

--- a/specs/scripts/linkMerchantUser.spec.ts
+++ b/specs/scripts/linkMerchantUser.spec.ts
@@ -64,6 +64,7 @@ describe('link-merchant-user script helpers', () => {
 
   it('parses merchant, email, password, role, and email confirmation flags', () => {
     const args = parseArgs([
+      '--',
       'mc_n1c0ffee',
       'Owner@Example.com',
       '--password',

--- a/specs/scripts/linkMerchantUser.spec.ts
+++ b/specs/scripts/linkMerchantUser.spec.ts
@@ -1,0 +1,152 @@
+import { expect } from 'chai';
+import { createRequire } from 'module';
+
+const require = createRequire(import.meta.url);
+const knexFactory = require('knex');
+const {
+  createOrFindSupabaseUser,
+  linkMerchantUser,
+  parseArgs,
+  resolveMerchant,
+} = require('../../scripts/link-merchant-user');
+
+function createFakeSupabase(initialUsers: Array<{ id: string; email: string }> = []) {
+  const users = [...initialUsers];
+  const createPayloads: any[] = [];
+  return {
+    users,
+    createPayloads,
+    auth: {
+      admin: {
+        listUsers: async ({ page, perPage }: { page: number; perPage: number }) => {
+          const start = (page - 1) * perPage;
+          return { data: { users: users.slice(start, start + perPage) }, error: null };
+        },
+        createUser: async (payload: any) => {
+          createPayloads.push(payload);
+          const user = { id: `user-${users.length + 1}`, email: payload.email };
+          users.push(user);
+          return { data: { user }, error: null };
+        },
+      },
+    },
+  };
+}
+
+describe('link-merchant-user script helpers', () => {
+  let db: any;
+
+  beforeEach(async () => {
+    db = knexFactory({
+      client: 'sqlite3',
+      connection: { filename: ':memory:' },
+      useNullAsDefault: true,
+    });
+
+    await db.schema.createTable('merchants', (table: any) => {
+      table.increments('id').primary();
+      table.string('business_name').notNullable();
+      table.string('uuid').notNullable().unique();
+      table.string('hash_id').notNullable().unique();
+    });
+    await db.schema.createTable('merchant_users', (table: any) => {
+      table.increments('id').primary();
+      table.integer('merchant_id').notNullable();
+      table.string('supabase_user_id').notNullable();
+      table.string('role').notNullable().defaultTo('owner');
+      table.unique(['merchant_id', 'supabase_user_id']);
+    });
+  });
+
+  afterEach(async () => {
+    await db.destroy();
+  });
+
+  it('parses merchant, email, password, role, and email confirmation flags', () => {
+    const args = parseArgs([
+      'mc_n1c0ffee',
+      'Owner@Example.com',
+      '--password',
+      'temporary',
+      '--role',
+      'admin',
+      '--no-email-confirm',
+    ]);
+
+    expect(args).to.include({
+      merchantParam: 'mc_n1c0ffee',
+      email: 'Owner@Example.com',
+      password: 'temporary',
+      role: 'admin',
+      emailConfirm: false,
+    });
+  });
+
+  it('creates a Supabase user when email is new', async () => {
+    const supabase = createFakeSupabase();
+    const result = await createOrFindSupabaseUser(supabase, 'Owner@Example.com', {
+      password: 'temporary',
+      emailConfirm: true,
+    });
+
+    expect(result.created).to.equal(true);
+    expect(result.user).to.deep.equal({ id: 'user-1', email: 'owner@example.com' });
+    expect(result.password).to.equal('temporary');
+    expect(supabase.createPayloads).to.deep.equal([
+      {
+        email: 'owner@example.com',
+        password: 'temporary',
+        email_confirm: true,
+      },
+    ]);
+  });
+
+  it('reuses an existing Supabase user with the same email', async () => {
+    const supabase = createFakeSupabase([{ id: 'existing-user', email: 'owner@example.com' }]);
+    const result = await createOrFindSupabaseUser(supabase, 'OWNER@example.com', {
+      password: 'temporary',
+      emailConfirm: true,
+    });
+
+    expect(result.created).to.equal(false);
+    expect(result.user.id).to.equal('existing-user');
+    expect(result.password).to.equal(null);
+    expect(supabase.createPayloads).to.deep.equal([]);
+  });
+
+  it('resolves merchants and links Supabase users idempotently', async () => {
+    const [merchantId] = await db('merchants').insert({
+      business_name: 'INSTEP Cafe',
+      uuid: 'a0000001-0001-0001-0001-000000000001',
+      hash_id: 'mc_n1c0ffee',
+    });
+
+    expect((await resolveMerchant(db, String(merchantId))).hash_id).to.equal('mc_n1c0ffee');
+    expect((await resolveMerchant(db, 'mc_n1c0ffee')).id).to.equal(merchantId);
+    expect((await resolveMerchant(db, 'a0000001-0001-0001-0001-000000000001')).id).to.equal(merchantId);
+
+    const created = await linkMerchantUser(db, {
+      merchantId,
+      supabaseUserId: 'supabase-user-1',
+      role: 'owner',
+    });
+    expect(created).to.include({ created: true, updated: false });
+
+    const unchanged = await linkMerchantUser(db, {
+      merchantId,
+      supabaseUserId: 'supabase-user-1',
+      role: 'owner',
+    });
+    expect(unchanged).to.include({ created: false, updated: false });
+
+    const updated = await linkMerchantUser(db, {
+      merchantId,
+      supabaseUserId: 'supabase-user-1',
+      role: 'admin',
+    });
+    expect(updated).to.include({ created: false, updated: true });
+
+    const row = await db('merchant_users').where({ merchant_id: merchantId }).first();
+    expect(row.role).to.equal('admin');
+  });
+});

--- a/src/client/css/pages/MerchantRoutes.css
+++ b/src/client/css/pages/MerchantRoutes.css
@@ -114,6 +114,22 @@
   align-items: center;
 }
 
+.OrdersGrid__nav-button {
+  color: #00e5ff;
+  font: inherit;
+  font-size: 0.95rem;
+  font-weight: 600;
+  background: transparent;
+  border: 0;
+  padding: 8px 12px;
+  min-height: 44px;
+  cursor: pointer;
+}
+
+.Merchant--theme-light .OrdersGrid__nav-button {
+  color: #555;
+}
+
 .OrdersGrid__cards {
   display: grid;
   grid-template-columns: 1fr;

--- a/src/client/js/App.tsx
+++ b/src/client/js/App.tsx
@@ -4,6 +4,8 @@ import {BrowserRouter, Route, Switch} from 'react-router-dom';
 import Lazy from './components/Lazy';
 import HomeLanding from './pages/HomeLanding';
 import { MERCHANT_DASHBOARD_PREFIXES } from '../../shared/merchant_dashboard';
+import MerchantProtectedRoute from './components/MerchantProtectedRoute';
+import { MerchantAuthProvider } from './context/MerchantAuthContext';
 
 // Global types are defined in src/types/global.d.ts
 
@@ -37,7 +39,8 @@ const MERCHANT_DASHBOARD_ROUTES = [
 
 function App() {
   return <div>
-    <BrowserRouter>
+    <MerchantAuthProvider>
+      <BrowserRouter>
 
       <Switch>
         <Route path="/" exact component={HomeLanding} />
@@ -50,7 +53,9 @@ function App() {
               key={`${prefix}${route.path}`}
               path={`${prefix}${route.path}`}
               exact={route.exact}
-              component={route.component}
+              render={(props) => (
+                <MerchantProtectedRoute component={route.component} routeProps={props} />
+              )}
             />
           ))
         )}
@@ -63,7 +68,8 @@ function App() {
         <Route path="/orders/:orderUuid/menus" exact component={Pages.Menus} />
       </Switch>
 
-    </BrowserRouter>
+      </BrowserRouter>
+    </MerchantAuthProvider>
   </div>
 }
 

--- a/src/client/js/components/MerchantAdminLayout.tsx
+++ b/src/client/js/components/MerchantAdminLayout.tsx
@@ -4,6 +4,7 @@ import type { MenuActionDescriptor, PageProps } from '@shopify/polaris';
 import { useTranslation } from 'react-i18next';
 import { merchantDashboardPath } from '../../../shared/merchant_dashboard';
 import MerchantPolarisProvider from './MerchantPolarisProvider';
+import { useMerchantAuth } from '../context/MerchantAuthContext';
 
 interface MerchantAdminLayoutProps {
   merchantHashId: string;
@@ -27,11 +28,13 @@ export default function MerchantAdminLayout({
   showNav = true,
 }: MerchantAdminLayoutProps) {
   const { t } = useTranslation();
+  const { signOut } = useMerchantAuth();
   const navActions = showNav
     ? [
         { content: t('merchant.menus'), url: merchantDashboardPath(merchantHashId, 'online-menus') },
         { content: t('merchant.menu'), url: merchantDashboardPath(merchantHashId, 'menuitems') },
         { content: t('merchant.settings'), url: merchantDashboardPath(merchantHashId, 'settings') },
+        { content: 'Sign out', onAction: signOut },
       ]
     : [];
 

--- a/src/client/js/components/MerchantLogin.tsx
+++ b/src/client/js/components/MerchantLogin.tsx
@@ -1,0 +1,79 @@
+import React, { useState } from 'react';
+import {
+  Banner,
+  Button,
+  Card,
+  Form,
+  FormLayout,
+  Page,
+  TextField,
+} from '@shopify/polaris';
+import MerchantPolarisProvider from './MerchantPolarisProvider';
+import { useMerchantAuth } from '../context/MerchantAuthContext';
+
+export default function MerchantLogin() {
+  const { configError, signIn } = useMerchantAuth();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async () => {
+    setError(null);
+    setSubmitting(true);
+    try {
+      await signIn(email.trim(), password);
+    } catch (err: any) {
+      setError(err.message || 'Unable to sign in');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <MerchantPolarisProvider>
+      <Page title="Merchant sign in">
+        {configError && (
+          <Banner status="critical">
+            {configError}
+          </Banner>
+        )}
+        <Card title="Sign in to manage your restaurant" sectioned>
+          <Form onSubmit={handleSubmit}>
+            <FormLayout>
+              {error && (
+                <Banner status="critical" onDismiss={() => setError(null)}>
+                  {error}
+                </Banner>
+              )}
+              <TextField
+                label="Email"
+                value={email}
+                onChange={setEmail}
+                autoComplete="email"
+                type="email"
+                disabled={Boolean(configError)}
+              />
+              <TextField
+                label="Password"
+                value={password}
+                onChange={setPassword}
+                autoComplete="current-password"
+                type="password"
+                disabled={Boolean(configError)}
+              />
+              <Button
+                primary
+                submit
+                loading={submitting}
+                disabled={Boolean(configError) || !email.trim() || !password}
+              >
+                Sign in
+              </Button>
+            </FormLayout>
+          </Form>
+        </Card>
+      </Page>
+    </MerchantPolarisProvider>
+  );
+}

--- a/src/client/js/components/MerchantProtectedRoute.tsx
+++ b/src/client/js/components/MerchantProtectedRoute.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import MerchantLogin from './MerchantLogin';
+import { useMerchantAuth } from '../context/MerchantAuthContext';
+
+interface MerchantProtectedRouteProps {
+  component: React.ComponentType<any>;
+  routeProps: any;
+}
+
+export default function MerchantProtectedRoute({
+  component: Component,
+  routeProps,
+}: MerchantProtectedRouteProps) {
+  const { loading, session } = useMerchantAuth();
+
+  if (loading) {
+    return (
+      <div className="Merchant Merchant__centered Merchant__loading">
+        Loading
+      </div>
+    );
+  }
+
+  if (!session) {
+    return <MerchantLogin />;
+  }
+
+  return <Component {...routeProps} />;
+}

--- a/src/client/js/context/MerchantAuthContext.tsx
+++ b/src/client/js/context/MerchantAuthContext.tsx
@@ -18,7 +18,7 @@ export function MerchantAuthProvider({ children }: { children: React.ReactNode }
   const [loading, setLoading] = useState(true);
   const configError = supabase
     ? null
-    : 'Supabase Auth is not configured. Set VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY.';
+    : 'Supabase Auth is not configured. Set VITE_SUPABASE_URL and VITE_SUPABASE_PUBLISHABLE_KEY.';
 
   useEffect(() => {
     if (!supabase) {

--- a/src/client/js/context/MerchantAuthContext.tsx
+++ b/src/client/js/context/MerchantAuthContext.tsx
@@ -1,0 +1,76 @@
+import React, { createContext, useContext, useEffect, useMemo, useState } from 'react';
+import type { Session } from '@supabase/supabase-js';
+import { getSupabaseClient } from '../lib/supabaseAuth';
+
+interface MerchantAuthContextValue {
+  configError: string | null;
+  loading: boolean;
+  session: Session | null;
+  signIn: (email: string, password: string) => Promise<void>;
+  signOut: () => Promise<void>;
+}
+
+const MerchantAuthContext = createContext<MerchantAuthContextValue | null>(null);
+
+export function MerchantAuthProvider({ children }: { children: React.ReactNode }) {
+  const supabase = useMemo(() => getSupabaseClient(), []);
+  const [session, setSession] = useState<Session | null>(null);
+  const [loading, setLoading] = useState(true);
+  const configError = supabase
+    ? null
+    : 'Supabase Auth is not configured. Set VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY.';
+
+  useEffect(() => {
+    if (!supabase) {
+      setLoading(false);
+      return;
+    }
+
+    let mounted = true;
+    supabase.auth.getSession().then(({ data }) => {
+      if (!mounted) return;
+      setSession(data.session);
+      setLoading(false);
+    });
+
+    const { data } = supabase.auth.onAuthStateChange((_event, nextSession) => {
+      setSession(nextSession);
+      setLoading(false);
+    });
+
+    return () => {
+      mounted = false;
+      data.subscription.unsubscribe();
+    };
+  }, [supabase]);
+
+  const value = useMemo<MerchantAuthContextValue>(() => ({
+    configError,
+    loading,
+    session,
+    signIn: async (email: string, password: string) => {
+      if (!supabase) throw new Error(configError || 'Supabase Auth is not configured');
+      const { error } = await supabase.auth.signInWithPassword({ email, password });
+      if (error) throw error;
+    },
+    signOut: async () => {
+      if (!supabase) return;
+      const { error } = await supabase.auth.signOut();
+      if (error) throw error;
+    },
+  }), [configError, loading, session, supabase]);
+
+  return (
+    <MerchantAuthContext.Provider value={value}>
+      {children}
+    </MerchantAuthContext.Provider>
+  );
+}
+
+export function useMerchantAuth() {
+  const context = useContext(MerchantAuthContext);
+  if (!context) {
+    throw new Error('useMerchantAuth must be used within MerchantAuthProvider');
+  }
+  return context;
+}

--- a/src/client/js/hooks/useMerchantHashRoute.ts
+++ b/src/client/js/hooks/useMerchantHashRoute.ts
@@ -25,11 +25,15 @@ export function useMerchantHashRoute(
     setError(null);
     setMerchant(null);
     fetchApi(`/api/merchants/${hashId}`)
-      .then((data) => {
-        if (data && data.id) setMerchant(data);
-        else setError(t('merchant.notFound'));
+      .then(async (data) => {
+        if (!data || !data.id) {
+          setError(t('merchant.notFound'));
+          return;
+        }
+        await fetchApi(`/api/merchants/${data.id}/authz`);
+        setMerchant(data);
       })
-      .catch(() => setError(t('merchant.loadFailed')));
+      .catch((err) => setError(err.message || t('merchant.loadFailed')));
   }, [hashId, t]);
 
   const merchantHashId = merchant?.hash_id || (isMerchantHashId(hashId) ? hashId : '');

--- a/src/client/js/hooks/useMerchantOrderStream.ts
+++ b/src/client/js/hooks/useMerchantOrderStream.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import type { OrderStreamPayload } from '../../../shared/order_events';
+import { postApi } from '../lib/merchantApi';
 
 export type ConnectionStatus = 'connecting' | 'live' | 'reconnecting';
 
@@ -14,8 +15,9 @@ export function useMerchantOrderStream(
   useEffect(() => {
     if (!merchantId) return;
 
+    let es: EventSource | null = null;
+    let closed = false;
     setConnectionStatus('connecting');
-    const es = new EventSource(`/api/merchants/${merchantId}/orders/stream`);
 
     const handleEvent = (e: MessageEvent) => {
       try {
@@ -26,13 +28,24 @@ export function useMerchantOrderStream(
       }
     };
 
-    es.addEventListener('order_created', handleEvent);
-    es.addEventListener('order_updated', handleEvent);
+    postApi(`/api/merchants/${merchantId}/orders/stream-token`, {})
+      .then((data) => {
+        if (closed) return;
+        const token = encodeURIComponent((data as { token: string }).token);
+        es = new EventSource(`/api/merchants/${merchantId}/orders/stream?token=${token}`);
 
-    es.onopen = () => setConnectionStatus('live');
-    es.onerror = () => setConnectionStatus('reconnecting');
+        es.addEventListener('order_created', handleEvent);
+        es.addEventListener('order_updated', handleEvent);
 
-    return () => es.close();
+        es.onopen = () => setConnectionStatus('live');
+        es.onerror = () => setConnectionStatus('reconnecting');
+      })
+      .catch(() => setConnectionStatus('reconnecting'));
+
+    return () => {
+      closed = true;
+      if (es) es.close();
+    };
   }, [merchantId]);
 
   return { connectionStatus };

--- a/src/client/js/lib/merchantApi.ts
+++ b/src/client/js/lib/merchantApi.ts
@@ -1,50 +1,61 @@
-export function fetchApi(url: string) {
-  return fetch(url, { credentials: 'same-origin' as const }).then((r) => r.json());
+import { getSupabaseAccessToken } from './supabaseAuth';
+
+async function authHeaders(extraHeaders: Record<string, string> = {}) {
+  const token = await getSupabaseAccessToken();
+  return {
+    ...extraHeaders,
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+  };
 }
 
-export function postApi(url: string, body: unknown) {
-  return fetch(url, {
+async function parseJsonResponse(r: Response) {
+  const data = await r.json().catch(() => ({}));
+  if (!r.ok) throw new Error((data as { error?: string })?.error || 'Request failed');
+  return data;
+}
+
+export async function fetchApi(url: string) {
+  const r = await fetch(url, {
+    credentials: 'same-origin' as const,
+    headers: await authHeaders({ Accept: 'application/json' }),
+  });
+  return parseJsonResponse(r);
+}
+
+export async function postApi(url: string, body: unknown) {
+  const r = await fetch(url, {
     method: 'POST',
     credentials: 'same-origin' as const,
-    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    headers: await authHeaders({ 'Content-Type': 'application/json', Accept: 'application/json' }),
     body: JSON.stringify(body),
-  }).then(async (r) => {
-    const data = await r.json().catch(() => ({}));
-    if (!r.ok) throw new Error((data as { error?: string })?.error || 'Request failed');
-    return data;
   });
+  return parseJsonResponse(r);
 }
 
-export function putApi(url: string, body: unknown) {
-  return fetch(url, {
+export async function putApi(url: string, body: unknown) {
+  const r = await fetch(url, {
     method: 'PUT',
     credentials: 'same-origin' as const,
-    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    headers: await authHeaders({ 'Content-Type': 'application/json', Accept: 'application/json' }),
     body: JSON.stringify(body),
-  }).then(async (r) => {
-    const data = await r.json().catch(() => ({}));
-    if (!r.ok) throw new Error((data as { error?: string })?.error || 'Request failed');
-    return data;
   });
+  return parseJsonResponse(r);
 }
 
-export function patchApi(url: string, body: unknown) {
-  return fetch(url, {
+export async function patchApi(url: string, body: unknown) {
+  const r = await fetch(url, {
     method: 'PATCH',
     credentials: 'same-origin' as const,
-    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    headers: await authHeaders({ 'Content-Type': 'application/json', Accept: 'application/json' }),
     body: JSON.stringify(body),
-  }).then(async (r) => {
-    const data = await r.json().catch(() => ({}));
-    if (!r.ok) throw new Error((data as { error?: string })?.error || 'Request failed');
-    return data;
   });
+  return parseJsonResponse(r);
 }
 
-export function deleteApi(url: string) {
+export async function deleteApi(url: string) {
   return fetch(url, {
     method: 'DELETE',
     credentials: 'same-origin' as const,
-    headers: { Accept: 'application/json' },
+    headers: await authHeaders({ Accept: 'application/json' }),
   });
 }

--- a/src/client/js/lib/supabaseAuth.ts
+++ b/src/client/js/lib/supabaseAuth.ts
@@ -6,13 +6,13 @@ export function getSupabaseClient(): SupabaseClient | null {
   if (client !== undefined) return client;
 
   const url = import.meta.env.VITE_SUPABASE_URL;
-  const anonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
-  if (!url || !anonKey) {
+  const publishableKey = import.meta.env.VITE_SUPABASE_PUBLISHABLE_KEY;
+  if (!url || !publishableKey) {
     client = null;
     return client;
   }
 
-  client = createClient(url, anonKey);
+  client = createClient(url, publishableKey);
   return client;
 }
 

--- a/src/client/js/lib/supabaseAuth.ts
+++ b/src/client/js/lib/supabaseAuth.ts
@@ -1,0 +1,29 @@
+import { createClient, type Session, type SupabaseClient } from '@supabase/supabase-js';
+
+let client: SupabaseClient | null | undefined;
+
+export function getSupabaseClient(): SupabaseClient | null {
+  if (client !== undefined) return client;
+
+  const url = import.meta.env.VITE_SUPABASE_URL;
+  const anonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+  if (!url || !anonKey) {
+    client = null;
+    return client;
+  }
+
+  client = createClient(url, anonKey);
+  return client;
+}
+
+export async function getSupabaseSession(): Promise<Session | null> {
+  const supabase = getSupabaseClient();
+  if (!supabase) return null;
+  const { data } = await supabase.auth.getSession();
+  return data.session;
+}
+
+export async function getSupabaseAccessToken(): Promise<string | null> {
+  const session = await getSupabaseSession();
+  return session?.access_token || null;
+}

--- a/src/client/js/pages/MerchantMenus.tsx
+++ b/src/client/js/pages/MerchantMenus.tsx
@@ -19,7 +19,7 @@ import MerchantAdminLayout from '../components/MerchantAdminLayout';
 import MerchantPolarisProvider from '../components/MerchantPolarisProvider';
 import { useMerchantHashRoute } from '../hooks/useMerchantHashRoute';
 import { merchantDashboardPath } from '../../../shared/merchant_dashboard';
-import { deleteApi, fetchApi } from '../lib/merchantApi';
+import { deleteApi, fetchApi, patchApi } from '../lib/merchantApi';
 
 const DAYS = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'];
 
@@ -109,12 +109,7 @@ function MenuList({
 
   const togglePublished = async (menuId: number, current: boolean) => {
     if (!merchant?.id) return;
-    await fetch(`/api/merchants/${merchant.id}/menus/${menuId}`, {
-      method: 'PATCH',
-      credentials: 'same-origin',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ isPublished: !current }),
-    });
+    await patchApi(`/api/merchants/${merchant.id}/menus/${menuId}`, { isPublished: !current });
     setMenus((prev) =>
       prev.map((m) => (m.id === menuId ? { ...m, is_published: !current } : m))
     );

--- a/src/client/js/pages/MerchantRoutes.tsx
+++ b/src/client/js/pages/MerchantRoutes.tsx
@@ -7,20 +7,9 @@ import { merchantDashboardPath } from '../../../shared/merchant_dashboard';
 import type { OrderStreamPayload } from '../../../shared/order_events';
 import { useMerchantHashRoute } from '../hooks/useMerchantHashRoute';
 import { useMerchantOrderStream, useElapsedTick, type ConnectionStatus } from '../hooks/useMerchantOrderStream';
+import { useMerchantAuth } from '../context/MerchantAuthContext';
+import { fetchApi, postApi } from '../lib/merchantApi';
 import '../../css/pages/MerchantRoutes.css';
-
-function fetchApi(url: string) {
-  return fetch(url, { credentials: 'same-origin' as const }).then(r => r.json());
-}
-
-function postApi(url: string, body: any) {
-  return fetch(url, {
-    method: 'POST',
-    credentials: 'same-origin' as const,
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body),
-  }).then(r => r.json());
-}
 
 // ─── Main Container ───
 
@@ -118,6 +107,7 @@ function OrdersListPage({ merchantId, merchantName, merchantHashId, onSelectOrde
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('active');
   const [highlightedIds, setHighlightedIds] = useState<Set<number>>(() => new Set());
   const highlightTimers = useRef<Map<number, ReturnType<typeof setTimeout>>>(new Map());
+  const { signOut } = useMerchantAuth();
   const isMobile = useIsMobile();
   const elapsedTick = useElapsedTick();
 
@@ -191,6 +181,7 @@ function OrdersListPage({ merchantId, merchantName, merchantHashId, onSelectOrde
           <a href={merchantDashboardPath(merchantHashId, 'online-menus')}>{t('merchant.menus')}</a>
           <a href={merchantDashboardPath(merchantHashId, 'menuitems')}>{t('merchant.menu')}</a>
           <a href={merchantDashboardPath(merchantHashId, 'settings')}>{t('merchant.settings')}</a>
+          <button type="button" className="OrdersGrid__nav-button" onClick={signOut}>Sign out</button>
           <ConnectionIndicator status={connectionStatus} t={t} />
           <span className="OrdersGrid__count">{filteredOrders.length}</span>
         </div>

--- a/src/server/middleware/merchantAuth.js
+++ b/src/server/middleware/merchantAuth.js
@@ -1,0 +1,208 @@
+const crypto = require('crypto');
+const { createClient } = require('@supabase/supabase-js');
+const MerchantUsers = require('../models/merchant_users').default;
+
+let supabaseClient = null;
+let supabaseUserResolverForTest = null;
+
+function getSupabaseConfig() {
+  const url = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL;
+  const key =
+    process.env.SUPABASE_SERVICE_ROLE_KEY ||
+    process.env.SUPABASE_ANON_KEY ||
+    process.env.VITE_SUPABASE_ANON_KEY;
+  return { url, key };
+}
+
+function getSupabaseClient() {
+  if (supabaseClient) return supabaseClient;
+  const { url, key } = getSupabaseConfig();
+  if (!url || !key) return null;
+  supabaseClient = createClient(url, key, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  });
+  return supabaseClient;
+}
+
+function extractBearerToken(req) {
+  const header = req.get('authorization') || '';
+  const match = header.match(/^Bearer\s+(.+)$/i);
+  return match ? match[1] : null;
+}
+
+async function resolveSupabaseUser(token) {
+  if (supabaseUserResolverForTest) {
+    return supabaseUserResolverForTest(token);
+  }
+
+  const client = getSupabaseClient();
+  if (!client) {
+    const err = new Error('Supabase Auth is not configured');
+    err.status = 503;
+    throw err;
+  }
+
+  const { data, error } = await client.auth.getUser(token);
+  if (error || !data?.user?.id) return null;
+  return {
+    id: data.user.id,
+    email: data.user.email || null,
+  };
+}
+
+async function requireSupabaseUser(req, res, next) {
+  try {
+    const token = extractBearerToken(req);
+    if (!token) {
+      return res.status(401).json({ error: 'Authentication required' });
+    }
+
+    const user = await resolveSupabaseUser(token);
+    if (!user?.id) {
+      return res.status(401).json({ error: 'Invalid authentication token' });
+    }
+
+    req.supabaseUser = user;
+    next();
+  } catch (err) {
+    const status = err.status || 500;
+    res.status(status).json({ error: err.message || 'Authentication failed' });
+  }
+}
+
+async function requireMerchantAccess(req, res, next) {
+  await requireSupabaseUser(req, res, async () => {
+    try {
+      const merchantId = parseInt(req.params.merchantId, 10);
+      if (Number.isNaN(merchantId)) {
+        return res.status(400).json({ error: 'Invalid merchant ID' });
+      }
+
+      const isLinked = await MerchantUsers.isUserLinkedToMerchant(
+        merchantId,
+        req.supabaseUser.id
+      );
+      if (!isLinked) {
+        return res.status(403).json({ error: 'Merchant access denied' });
+      }
+
+      req.merchantAuth = {
+        merchantId,
+        supabaseUserId: req.supabaseUser.id,
+      };
+      next();
+    } catch (err) {
+      res.status(500).json({ error: err.message || 'Merchant authorization failed' });
+    }
+  });
+}
+
+function getStreamSecret() {
+  return (
+    process.env.MERCHANT_AUTH_STREAM_SECRET ||
+    process.env.SESSION_SECRET ||
+    process.env.SUPABASE_JWT_SECRET ||
+    process.env.SUPABASE_SERVICE_ROLE_KEY ||
+    process.env.SUPABASE_ANON_KEY ||
+    process.env.VITE_SUPABASE_ANON_KEY
+  );
+}
+
+function encodeBase64Url(value) {
+  return Buffer.from(value).toString('base64url');
+}
+
+function signPayload(payload, secret) {
+  return crypto.createHmac('sha256', secret).update(payload).digest('base64url');
+}
+
+function createMerchantStreamToken({ merchantId, supabaseUserId, ttlMs = 60_000 }) {
+  const secret = getStreamSecret();
+  if (!secret) {
+    const err = new Error('Merchant stream auth is not configured');
+    err.status = 503;
+    throw err;
+  }
+
+  const payload = encodeBase64Url(
+    JSON.stringify({
+      merchantId,
+      supabaseUserId,
+      expiresAt: Date.now() + ttlMs,
+    })
+  );
+  return `${payload}.${signPayload(payload, secret)}`;
+}
+
+function verifyMerchantStreamToken(token) {
+  const secret = getStreamSecret();
+  if (!secret) {
+    const err = new Error('Merchant stream auth is not configured');
+    err.status = 503;
+    throw err;
+  }
+
+  const [payload, signature] = String(token || '').split('.');
+  if (!payload || !signature) return null;
+
+  const expected = signPayload(payload, secret);
+  const actualBuffer = Buffer.from(signature);
+  const expectedBuffer = Buffer.from(expected);
+  if (
+    actualBuffer.length !== expectedBuffer.length ||
+    !crypto.timingSafeEqual(actualBuffer, expectedBuffer)
+  ) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(Buffer.from(payload, 'base64url').toString('utf8'));
+    if (!parsed.expiresAt || parsed.expiresAt < Date.now()) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+async function requireMerchantStreamAccess(req, res, next) {
+  try {
+    const merchantId = parseInt(req.params.merchantId, 10);
+    if (Number.isNaN(merchantId)) return res.sendStatus(400);
+
+    const token = req.query.token;
+    const payload = verifyMerchantStreamToken(token);
+    if (!payload || payload.merchantId !== merchantId || !payload.supabaseUserId) {
+      return res.sendStatus(401);
+    }
+
+    const isLinked = await MerchantUsers.isUserLinkedToMerchant(
+      merchantId,
+      payload.supabaseUserId
+    );
+    if (!isLinked) return res.sendStatus(403);
+
+    req.merchantAuth = {
+      merchantId,
+      supabaseUserId: payload.supabaseUserId,
+    };
+    next();
+  } catch (err) {
+    res.status(err.status || 500).json({ error: err.message || 'Stream authorization failed' });
+  }
+}
+
+function setSupabaseUserResolverForTest(resolver) {
+  supabaseUserResolverForTest = resolver;
+}
+
+module.exports = {
+  createMerchantStreamToken,
+  requireMerchantAccess,
+  requireMerchantStreamAccess,
+  requireSupabaseUser,
+  setSupabaseUserResolverForTest,
+  verifyMerchantStreamToken,
+};

--- a/src/server/middleware/merchantAuth.js
+++ b/src/server/middleware/merchantAuth.js
@@ -7,10 +7,7 @@ let supabaseUserResolverForTest = null;
 
 function getSupabaseConfig() {
   const url = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL;
-  const key =
-    process.env.SUPABASE_SERVICE_ROLE_KEY ||
-    process.env.SUPABASE_ANON_KEY ||
-    process.env.VITE_SUPABASE_ANON_KEY;
+  const key = process.env.SUPABASE_SECRET_KEY;
   return { url, key };
 }
 
@@ -105,9 +102,7 @@ function getStreamSecret() {
     process.env.MERCHANT_AUTH_STREAM_SECRET ||
     process.env.SESSION_SECRET ||
     process.env.SUPABASE_JWT_SECRET ||
-    process.env.SUPABASE_SERVICE_ROLE_KEY ||
-    process.env.SUPABASE_ANON_KEY ||
-    process.env.VITE_SUPABASE_ANON_KEY
+    process.env.SUPABASE_SECRET_KEY
   );
 }
 

--- a/src/server/middleware/merchantAuth.js
+++ b/src/server/middleware/merchantAuth.js
@@ -37,7 +37,9 @@ async function resolveSupabaseUser(token) {
 
   const client = getSupabaseClient();
   if (!client) {
-    const err = new Error('Supabase Auth is not configured');
+    const err = new Error(
+      'Supabase Auth is not configured. Set VITE_SUPABASE_URL and SUPABASE_SECRET_KEY.'
+    );
     err.status = 503;
     throw err;
   }

--- a/src/server/models/merchant_users.ts
+++ b/src/server/models/merchant_users.ts
@@ -1,0 +1,52 @@
+import db from './db';
+import { extractInsertId } from '../db/insert-id';
+
+export interface MerchantUserRow {
+  id: number;
+  merchant_id: number;
+  supabase_user_id: string;
+  role: string;
+  created_at: string;
+}
+
+const T = () => db('merchant_users');
+
+class MerchantUsers {
+  static async link(params: {
+    merchantId: number;
+    supabaseUserId: string;
+    role?: string;
+  }): Promise<number> {
+    const result = await T()
+      .insert({
+        merchant_id: params.merchantId,
+        supabase_user_id: params.supabaseUserId,
+        role: params.role || 'owner',
+      })
+      .returning('id');
+    return extractInsertId(result);
+  }
+
+  static async getForMerchantUser(
+    merchantId: number,
+    supabaseUserId: string,
+  ): Promise<MerchantUserRow | undefined> {
+    return T()
+      .select()
+      .where({
+        merchant_id: merchantId,
+        supabase_user_id: supabaseUserId,
+      })
+      .first();
+  }
+
+  static async isUserLinkedToMerchant(
+    merchantId: number,
+    supabaseUserId: string,
+  ): Promise<boolean> {
+    const row = await this.getForMerchantUser(merchantId, supabaseUserId);
+    return Boolean(row);
+  }
+}
+
+export default MerchantUsers;

--- a/src/server/routes/merchants.js
+++ b/src/server/routes/merchants.js
@@ -12,6 +12,11 @@ const { categoriesRouter } = require('./menu_categories');
 const { subscribeMerchantOrders } = require('../services/order_events');
 const { normalizeMenuItemImageUrl } = require('../lib/s3');
 const {
+    createMerchantStreamToken,
+    requireMerchantAccess,
+    requireMerchantStreamAccess,
+} = require('../middleware/merchantAuth');
+const {
     createMenuItemImagePresign,
     completeMenuItemImageUpload,
     deleteMenuItemImage,
@@ -36,6 +41,14 @@ router.get('/:param', async (req, res) => {
         res.sendStatus(404);
     }
 });
+
+router.get('/:merchantId/orders/stream', requireMerchantStreamAccess, (req, res) => {
+    const merchantId = parseInt(req.params.merchantId, 10);
+    if (isNaN(merchantId)) return res.sendStatus(400);
+    subscribeMerchantOrders(merchantId, res);
+});
+
+router.use('/:merchantId', requireMerchantAccess);
 
 // ─── Merchant Settings (business info, theme) ───
 
@@ -83,11 +96,14 @@ async function updateMerchantSettingsHandler(req, res) {
 router.patch('/:merchantId', updateMerchantSettingsHandler);
 router.put('/:merchantId', updateMerchantSettingsHandler);
 
-
-router.get('/:merchantId/orders/stream', (req, res) => {
+router.post('/:merchantId/orders/stream-token', (req, res) => {
     const merchantId = parseInt(req.params.merchantId, 10);
-    if (isNaN(merchantId)) return res.sendStatus(400);
-    subscribeMerchantOrders(merchantId, res);
+    if (isNaN(merchantId)) return res.status(400).json({ error: 'Invalid merchant ID' });
+    const token = createMerchantStreamToken({
+        merchantId,
+        supabaseUserId: req.supabaseUser.id,
+    });
+    res.json({ token });
 });
 
 router.get('/:merchantId/orders', async (req, res) => {

--- a/src/server/routes/merchants.js
+++ b/src/server/routes/merchants.js
@@ -96,6 +96,10 @@ async function updateMerchantSettingsHandler(req, res) {
 router.patch('/:merchantId', updateMerchantSettingsHandler);
 router.put('/:merchantId', updateMerchantSettingsHandler);
 
+router.get('/:merchantId/authz', (req, res) => {
+    res.json({ ok: true });
+});
+
 router.post('/:merchantId/orders/stream-token', (req, res) => {
     const merchantId = parseInt(req.params.merchantId, 10);
     if (isNaN(merchantId)) return res.status(400).json({ error: 'Invalid merchant ID' });

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -7,7 +7,7 @@ declare global {
 
   interface ImportMetaEnv {
     readonly VITE_SUPABASE_URL?: string;
-    readonly VITE_SUPABASE_ANON_KEY?: string;
+    readonly VITE_SUPABASE_PUBLISHABLE_KEY?: string;
   }
 
   interface ImportMeta {

--- a/src/types/global.d.ts
+++ b/src/types/global.d.ts
@@ -4,6 +4,15 @@ declare global {
   interface Window {
     __VARS__?: any;
   }
+
+  interface ImportMetaEnv {
+    readonly VITE_SUPABASE_URL?: string;
+    readonly VITE_SUPABASE_ANON_KEY?: string;
+  }
+
+  interface ImportMeta {
+    readonly env: ImportMetaEnv;
+  }
 }
 
 export { };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add `merchant_users` ownership mapping for Supabase Auth users.
- Protect merchant admin APIs with Supabase bearer-token validation and merchant ownership checks.
- Add a merchant dashboard authorization preflight endpoint.
- Add short-lived stream tokens for authenticated order SSE connections.
- Add merchant dashboard login/session/logout plumbing with Supabase client config.
- Use Supabase's newer key names: `VITE_SUPABASE_PUBLISHABLE_KEY` for browser auth and `SUPABASE_SECRET_KEY` for server/admin operations.
- Use `VITE_SUPABASE_URL` as the single required Supabase project URL; `SUPABASE_URL` remains an optional server-only override.
- Add `pnpm run link-merchant-user` to create/reuse Supabase Auth users and link them to merchants.
- Merge latest `origin/main` into this branch.
- Document required Supabase environment variables.

## Tests
- `DB_CLIENT=sqlite3 DB_FILENAME=test.db NODE_ENV=development pnpm exec mocha specs/routes/merchantAuth.spec.ts specs/scripts/linkMerchantUser.spec.ts --exit`
- `pnpm test`
- `pnpm run build`
- `pnpm run build:server` (fails on existing customer/order TypeScript issues: `CustomerCreateParams.email`, `OrderRow` index signature)

## Notes
- The server TypeScript build failure is unchanged from before this work and unrelated to the merchant auth changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2d13c3ac-db2c-44dc-a016-7a9d3910e2c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2d13c3ac-db2c-44dc-a016-7a9d3910e2c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

