### PR TITLE
KDS card layout fixes: visible items, smaller text, cleaner labels

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqc-nodejs-demo",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "private": true,
   "main": "src/server/index.js",
   "scripts": {

--- a/src/client/css/pages/MerchantRoutes.css
+++ b/src/client/css/pages/MerchantRoutes.css
@@ -192,19 +192,20 @@
   }
 
   .OrderCard__orderNum {
-    font-size: clamp(1.1rem, 2.2vw, 1.35rem);
+    font-size: clamp(0.95rem, 1.8vw, 1.1rem);
     line-height: 1;
   }
 
   .OrderCard__time {
-    font-size: 0.75rem;
+    font-size: 0.7rem;
   }
 
   .OrderCard__items {
-    flex: 1 1 auto;
-    min-height: 0;
-    font-size: 0.78rem;
-    line-height: 1.25;
+    flex: 0 0 auto;
+    min-height: auto;
+    font-size: 0.75rem;
+    line-height: 1.2;
+    margin-bottom: 2px;
   }
 
   .OrderCard__item {
@@ -226,9 +227,9 @@
 
   .OrderCard__customer {
     flex-shrink: 0;
-    margin-bottom: 4px;
-    font-size: 0.82rem;
-    line-height: 1.2;
+    margin-bottom: 2px;
+    font-size: 0.7rem;
+    line-height: 1.15;
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -288,7 +289,7 @@
 }
 
 .OrderCard__orderNum {
-  font-size: 1.75rem;
+  font-size: 1.35rem;
   font-weight: 800;
   color: #fff;
   letter-spacing: -0.02em;
@@ -302,18 +303,19 @@
 }
 
 .OrderCard__customer {
-  font-size: 1.05rem;
+  font-size: 0.875rem;
   color: #ddd;
-  margin-bottom: 8px;
+  margin-bottom: 6px;
   font-weight: 600;
-  line-height: 1.3;
+  line-height: 1.25;
+  flex-shrink: 0;
 }
 
 .OrderCard__items {
-  flex: 1;
+  flex: 0 0 auto;
   color: #999;
-  font-size: 0.95rem;
-  line-height: 1.4;
+  font-size: 0.9rem;
+  line-height: 1.35;
   overflow: hidden;
 }
 

--- a/src/client/locales/en.yaml
+++ b/src/client/locales/en.yaml
@@ -164,7 +164,7 @@ merchant:
   deleteModifierConfirm: "Delete this modifier?"
 
 orderStatus:
-  waiting_for_acceptance: "Waiting for Acceptance"
+  waiting_for_acceptance: "Accept Order"
   accepted: "Order Accepted"
   preparing: "Preparing"
   ready_for_pickup: "Ready for Pickup"
@@ -176,8 +176,8 @@ orderStatus:
   refunded: "Refunded"
 
 orderType:
-  delivery: "🚗 Delivery"
-  pickup: "🏪 Pickup"
+  delivery: "Delivery"
+  pickup: "Pickup"
 
 time:
   justNow: "Just now"

--- a/src/client/locales/ms.yaml
+++ b/src/client/locales/ms.yaml
@@ -156,7 +156,7 @@ merchant:
   deleteModifierConfirm: "Padam modifier ini?"
 
 orderStatus:
-  waiting_for_acceptance: "Menunggu Penerimaan"
+  waiting_for_acceptance: "Terima Pesanan"
   accepted: "Pesanan Diterima"
   preparing: "Sedang Disediakan"
   ready_for_pickup: "Sedia untuk Ambil Sendiri"
@@ -168,8 +168,8 @@ orderStatus:
   refunded: "Bayaran Dikembalikan"
 
 orderType:
-  delivery: "🚗 Penghantaran"
-  pickup: "🏪 Ambil Sendiri"
+  delivery: "Penghantaran"
+  pickup: "Ambil Sendiri"
 
 time:
   justNow: "Baru sahaja"

--- a/src/client/locales/zh.yaml
+++ b/src/client/locales/zh.yaml
@@ -159,7 +159,7 @@ merchant:
   deleteModifierConfirm: "确定删除此配料？"
 
 orderStatus:
-  waiting_for_acceptance: "待接单"
+  waiting_for_acceptance: "接受订单"
   accepted: "已接单"
   preparing: "制作中"
   ready_for_pickup: "待自取"
@@ -171,8 +171,8 @@ orderStatus:
   refunded: "已退款"
 
 orderType:
-  delivery: "🚗 配送"
-  pickup: "🏪 自取"
+  delivery: "配送"
+  pickup: "自取"
 
 time:
   justNow: "刚刚"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Fixes KDS order card layout and label issues found during staging verification.

- **Line items visible**: stop `.OrderCard__items` from flex-collapsing to 0px height
- **Smaller typography**: reduce order number and customer name on cards
- **Status label**: `waiting_for_acceptance` → "Accept Order" (en) / matching strings in zh & ms
- **Type tags**: remove 🏪/🚗 icons from Pickup/Delivery labels

## Test plan
- [ ] Open staging KDS at 1024px width
- [ ] Confirm Chai Latte / Croissant lines show on each ticket
- [ ] Confirm order #, customer, and badges are readable
- [ ] Confirm bottom row shows "Pickup" and "Accept Order" without icons
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a40c83aa-4442-409d-86c8-ee5fd50c58b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a40c83aa-4442-409d-86c8-ee5fd50c58b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

