### PR TITLE
Add git commit author policy for Cursor Agent

### DIFF
--- a/.cursor/rules/git-commit-author.mdc
+++ b/.cursor/rules/git-commit-author.mdc
@@ -1,0 +1,55 @@
+---
+description: All git commits must be attributed to Cursor Agent only
+globs:
+alwaysApply: true
+---
+
+# Git commit author policy
+
+Every commit on this project must be attributed **only** to Cursor Agent.
+
+## Git identity (this repo)
+
+Before committing, ensure local git config for this repository:
+
+```bash
+git config user.name "Cursor Agent"
+git config user.email "cursor-agent@local"
+```
+
+Do **not** set `user.name` or `user.email` to any other person or bot name.
+
+Enable the repo hook after clone:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+The hook removes injected `Co-authored-by:` trailers and ensures the required footer.
+
+## Commit message
+
+Every commit message must end with this line (exact text):
+
+```
+Authored by Cursor Agent
+```
+
+Example:
+
+```
+KDS: scrollable auto-height grid on tablet
+
+- Replace fixed equal-height rows with auto-height grid
+- Make cards area vertically scrollable
+
+Authored by Cursor Agent
+```
+
+## Do not use
+
+- `Co-authored-by:` trailers with other names
+- Other author attribution lines (e.g. `Signed-off-by:`, human names, emails)
+- Commit messages without the required `Authored by Cursor Agent` footer
+
+See also: `AGENTS.md` → Git commit author policy.

--- a/.githooks/prepare-commit-msg
+++ b/.githooks/prepare-commit-msg
@@ -1,0 +1,13 @@
+#!/bin/sh
+# Ensures commits follow the Cursor Agent author policy.
+COMMIT_MSG_FILE=$1
+
+# Remove any Co-authored-by trailers injected by the environment
+if [ -f "$COMMIT_MSG_FILE" ]; then
+  sed -i '/^Co-authored-by:/Id' "$COMMIT_MSG_FILE"
+  sed -i '/^Signed-off-by:/Id' "$COMMIT_MSG_FILE"
+
+  if ! grep -q '^Authored by Cursor Agent$' "$COMMIT_MSG_FILE"; then
+    printf '\nAuthored by Cursor Agent\n' >> "$COMMIT_MSG_FILE"
+  fi
+fi

--- a/.gitmessage
+++ b/.gitmessage
@@ -1,0 +1,5 @@
+# <subject: imperative summary, ~50 chars>
+
+# <optional body: what changed and why>
+
+Authored by Cursor Agent

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,6 +121,33 @@ Set `STAGING_MERCHANT_KEY` and `STAGING_MENU_SLUG` in `.env.staging.example` for
 - After merge, push is enough for Railway auto-deploy; run `pnpm run smoke:staging` when the user asks to redeploy.
 - If the user says to abort previous merges, revert only the commits they mean — confirm which PR numbers if unclear.
 
+### Git commit author policy
+
+All commits on this project must be attributed **only** to Cursor Agent.
+
+**Git identity** (per repository):
+
+```bash
+git config user.name "Cursor Agent"
+git config user.email "cursor-agent@local"
+```
+
+**Commit message footer** — every commit must end with this exact line:
+
+```
+Authored by Cursor Agent
+```
+
+Do not add `Co-authored-by:` or any other author names. Optional commit template: `.gitmessage` (`git config commit.template .gitmessage`).
+
+Enable the repo hook (strips injected co-author trailers, appends footer if missing):
+
+```bash
+git config core.hooksPath .githooks
+```
+
+Cursor rule: `.cursor/rules/git-commit-author.mdc`
+
 ### Optional integrations
 
 The contact form currently logs submissions to stdout; a database-backed admin UI is planned.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Adds a project-wide rule that all commits must be attributed only to **Cursor Agent**.

- **AGENTS.md** — git identity + required commit footer
- **`.cursor/rules/git-commit-author.mdc`** — always-on agent rule
- **`.gitmessage`** — optional commit template
- **`.githooks/prepare-commit-msg`** — strips injected `Co-authored-by:` trailers and appends footer if missing

## Setup (per clone)
```bash
git config user.name "Cursor Agent"
git config user.email "cursor-agent@local"
git config commit.template .gitmessage
git config core.hooksPath .githooks
```

Every commit message must end with:
```
Authored by Cursor Agent
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a40c83aa-4442-409d-86c8-ee5fd50c58b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a40c83aa-4442-409d-86c8-ee5fd50c58b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

