### PR TITLE
Fix KDS ticket overlap with flex-wrap scroll layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqc-nodejs-demo",
-  "version": "0.7.12",
+  "version": "0.7.13",
   "private": true,
   "main": "src/server/index.js",
   "scripts": {

--- a/src/client/css/pages/MerchantRoutes.css
+++ b/src/client/css/pages/MerchantRoutes.css
@@ -139,34 +139,38 @@
   }
 }
 
-/* Tablet+: KDS 3-column scrollable grid, variable-height tickets */
+/* Tablet+: KDS 3-column scrollable masonry-style tickets */
 @media (min-width: 768px) {
   .OrdersGrid {
     height: 100dvh;
-    display: grid;
-    grid-template-rows: auto auto minmax(0, 1fr);
-    grid-template-columns: 1fr;
+    max-height: 100dvh;
+    display: flex;
+    flex-direction: column;
     gap: 8px;
     padding: 8px 12px 12px;
     overflow: hidden;
+    box-sizing: border-box;
   }
 
   .OrdersGrid__header {
     padding: 4px 4px 0;
+    flex-shrink: 0;
   }
 
   .OrdersGrid__filters {
-    align-self: start;
+    flex-shrink: 0;
     padding: 0 4px 4px;
     justify-content: flex-start;
   }
 
   .OrdersGrid__cards {
-    grid-template-columns: repeat(3, 1fr);
-    grid-auto-rows: auto;
-    align-content: start;
-    align-items: start;
+    display: flex;
+    flex: 1 1 auto;
+    flex-wrap: wrap;
+    align-content: flex-start;
+    align-items: stretch;
     gap: 8px;
+    overflow-x: hidden;
     overflow-y: auto;
     min-height: 0;
     -webkit-overflow-scrolling: touch;
@@ -185,12 +189,15 @@
   }
 
   .OrderCard {
+    box-sizing: border-box;
+    flex: 0 0 calc((100% - 16px) / 3);
+    width: calc((100% - 16px) / 3);
     padding: 8px 10px;
-    min-height: auto;
+    min-height: 0;
     height: auto;
-    align-self: start;
     border-width: 2px;
     border-radius: 10px;
+    contain: none;
   }
 
   .OrderCard__top {
@@ -260,6 +267,10 @@
     font-size: 0.62rem;
     border-radius: 5px;
     letter-spacing: 0.02em;
+  }
+
+  .OrdersGrid__empty {
+    flex: 1 1 100%;
   }
 
   .OrderDetail__meta-comment {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Fixes overlapping order tickets on tablet KDS.

**Root cause:** CSS grid row tracks were sizing to ~120px (from `min-height` + `contain: layout`) while cards rendered taller (~184px+), causing vertical overlap.

**Fix:** Switch tablet card area to **flex-wrap** with fixed 3-column widths and **vertical scroll**, so each ticket uses its natural height.

## Test plan
- [ ] Open KDS at 1024px with 10+ orders
- [ ] Confirm no vertical overlap between tickets
- [ ] Confirm grid area scrolls vertically
- [ ] Confirm bottom Pickup / Accept Order badges visible on all tickets
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a40c83aa-4442-409d-86c8-ee5fd50c58b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a40c83aa-4442-409d-86c8-ee5fd50c58b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

