### PR TITLE
Fix KDS filter pill active/inactive styling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqc-nodejs-demo",
-  "version": "0.7.14",
+  "version": "0.7.15",
   "private": true,
   "main": "src/server/index.js",
   "scripts": {

--- a/src/client/css/pages/MerchantRoutes.css
+++ b/src/client/css/pages/MerchantRoutes.css
@@ -1029,25 +1029,23 @@
   font-size: 0.95rem;
   font-weight: 700;
   border: 2px solid #333;
-  background: #141414;
-  color: #888;
+  background: #1a1a1a;
+  color: #666;
   cursor: pointer;
   white-space: nowrap;
   transition: none;
   touch-action: manipulation;
 }
 
-.OrdersGrid__pill--active-color {
-  color: #00E5FF;
-}
-
+.OrdersGrid__pill--active-color,
 .OrdersGrid__pill--canceled-color {
-  color: #FF1744;
+  color: #666;
 }
 
 .OrdersGrid__pill--active {
-  background: #1a1a1a;
-  border-color: currentColor;
+  background: #fff;
+  border-color: #ddd;
+  color: #1a1a1a;
 }
 
 /* ===== Sections (Awaiting / Ready / Canceled) ===== */
@@ -1159,13 +1157,21 @@
 }
 
 .Merchant--theme-light .OrdersGrid__pill {
-  background: #fff;
-  border-color: #ddd;
-  color: #666;
+  background: #e0e0e0;
+  border-color: #e0e0e0;
+  color: #888;
+}
+
+.Merchant--theme-light .OrdersGrid__pill--active-color,
+.Merchant--theme-light .OrdersGrid__pill--canceled-color {
+  color: #888;
 }
 
 .Merchant--theme-light .OrdersGrid__pill--active {
-  background: #f0f0f0;
+  background: #fff;
+  border-color: #ddd;
+  color: #1a1a1a;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
 }
 
 .Merchant--theme-light .OrderDetail__total {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Fixes KDS status filter pill styling:
- **Selected** filter (Active or Canceled/Refunded): white background, dark text
- **Unselected** filter: grey background and muted grey text

## Test plan
- [ ] Open KDS on light theme
- [ ] Confirm Active tab is white when selected, Canceled tab greyed out
- [ ] Switch to Canceled/Refunded and confirm styling swaps
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a40c83aa-4442-409d-86c8-ee5fd50c58b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a40c83aa-4442-409d-86c8-ee5fd50c58b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

