### PR TITLE
Fix KDS order detail back button visibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqc-nodejs-demo",
-  "version": "0.7.15",
+  "version": "0.7.16",
   "private": true,
   "main": "src/server/index.js",
   "scripts": {

--- a/src/client/css/pages/MerchantRoutes.css
+++ b/src/client/css/pages/MerchantRoutes.css
@@ -52,6 +52,11 @@
 .Merchant--theme-light .ReasonModal {
   background: #fff;
   border-color: #ddd;
+  color: #1a1a1a;
+}
+
+.Merchant--theme-light .OrderDetail__back:active {
+  background: #f0f0f0;
 }
 
 .Merchant--theme-light .ReasonModal h3,
@@ -577,6 +582,28 @@
   -webkit-tap-highlight-color: transparent;
 }
 
+.OrderDetail__toolbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 16px;
+  flex-shrink: 0;
+}
+
+.OrderDetail__loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  font-size: 1.5rem;
+  color: #666;
+  min-height: 40vh;
+}
+
+.Merchant--theme-light .OrderDetail__loading {
+  color: #888;
+}
+
 .OrderDetail__back {
   background: #1a1a1a;
   border: 2px solid #444;
@@ -587,10 +614,12 @@
   cursor: pointer;
   font-size: 1.1rem;
   font-weight: 700;
-  margin-bottom: 16px;
-  width: 100%;
-  max-width: 200px;
+  margin-bottom: 0;
+  width: auto;
+  min-width: 160px;
+  max-width: 100%;
   touch-action: manipulation;
+  font-family: inherit;
 }
 
 .OrderDetail__back:active {

--- a/src/client/js/pages/MerchantRoutes.tsx
+++ b/src/client/js/pages/MerchantRoutes.tsx
@@ -448,8 +448,13 @@ function OrderDetailPage({ merchantId, orderId, onBack, t }: { merchantId: numbe
 
   if (!order) {
     return (
-      <div className="OrderDetail" style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', fontSize: '1.5rem', color: '#666' }}>
-        {t('common.loading')}
+      <div className="OrderDetail">
+        <div className="OrderDetail__toolbar">
+          <button type="button" className="OrderDetail__back" onClick={onBack}>
+            {t('merchant.backToOrders')}
+          </button>
+        </div>
+        <div className="OrderDetail__loading">{t('common.loading')}</div>
       </div>
     );
   }
@@ -467,8 +472,8 @@ function OrderDetailPage({ merchantId, orderId, onBack, t }: { merchantId: numbe
 
   return (
     <div className="OrderDetail">
-      <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginBottom: 16 }}>
-        <button className="OrderDetail__back" onClick={onBack}>
+      <div className="OrderDetail__toolbar">
+        <button type="button" className="OrderDetail__back" onClick={onBack}>
           {t('merchant.backToOrders')}
         </button>
         <ConnectionIndicator status={connectionStatus} t={t} />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
The order detail view already had a back button, but it was **invisible on the light KDS theme** (white text on white background).

- Set dark text color on `.OrderDetail__back` in light theme
- Show back button while order detail is loading
- Use a consistent toolbar row for back + live indicator

## Test plan
- [ ] Open an order from KDS on staging (light theme)
- [ ] Confirm "Back to Orders" button is visible and returns to the grid
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a40c83aa-4442-409d-86c8-ee5fd50c58b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a40c83aa-4442-409d-86c8-ee5fd50c58b4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

