### PR TITLE
Fix overflow order ticket stack display

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqc-nodejs-demo",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "private": true,
   "main": "src/server/index.js",
   "scripts": {

--- a/src/client/css/pages/MerchantRoutes.css
+++ b/src/client/css/pages/MerchantRoutes.css
@@ -947,25 +947,25 @@
   cursor: pointer;
   box-sizing: border-box;
   width: 100%;
-  min-height: 150px;
+  overflow: visible;
 }
 
 .OrderPile__stack {
   position: relative;
-  min-height: 140px;
+  margin-bottom: 20px;
 }
 
 .OrderPile__layer--back {
   position: absolute;
-  left: calc(var(--pile-layer, 1) * 4px);
-  right: calc(var(--pile-layer, 1) * -4px);
-  top: calc(var(--pile-layer, 1) * 8px);
-  height: calc(100% - var(--pile-layer, 1) * 8px);
-  min-height: 120px;
+  inset: 0;
   border-radius: 10px;
   border: 2px solid #333;
   background: #101010;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.35);
+  transform:
+    translateY(calc(var(--pile-layer, 1) * 7px))
+    scale(calc(1 - (var(--pile-layer, 1) * 0.018)));
+  transform-origin: top center;
   z-index: calc(10 - var(--pile-layer, 1));
 }
 
@@ -983,10 +983,10 @@
 }
 
 .OrderPile__label {
-  margin-top: 8px;
+  margin-top: 4px;
   text-align: center;
   color: #00e5ff;
-  font-size: 0.8rem;
+  font-size: 0.85rem;
   font-weight: 800;
   text-transform: uppercase;
   letter-spacing: 0.04em;

--- a/src/client/js/pages/MerchantRoutes.tsx
+++ b/src/client/js/pages/MerchantRoutes.tsx
@@ -106,13 +106,16 @@ function sortFifo(a: any, b: any) {
 
 function splitActiveBoard(awaitingPreparing: any[], ready: any[], limit = KDS_FULL_ORDER_LIMIT) {
   const globalFifo = [...awaitingPreparing, ...ready].sort(sortFifo);
-  const fullIds = new Set(globalFifo.slice(0, limit).map((order) => order.orderId));
-  const pileOrders = globalFifo.slice(limit);
+  const hasOverflow = globalFifo.length > limit;
+  const visibleFullLimit = hasOverflow ? Math.max(limit - 1, 0) : limit;
+  const fullIds = new Set(globalFifo.slice(0, visibleFullLimit).map((order) => order.orderId));
+  const pileFrontOrder = hasOverflow ? globalFifo[visibleFullLimit] : null;
+  const hiddenPileOrders = hasOverflow ? globalFifo.slice(visibleFullLimit + 1) : [];
   const activeFull = awaitingPreparing.filter((order) => fullIds.has(order.orderId));
   const readyFull = ready.filter((order) => fullIds.has(order.orderId));
   const showDivider = activeFull.length > 0 && ready.length > 0;
 
-  return { activeFull, readyFull, pileOrders, showDivider };
+  return { activeFull, readyFull, pileFrontOrder, hiddenPileOrders, showDivider };
 }
 
 function todayISO() {
@@ -253,9 +256,10 @@ function OrdersListPage({ merchantId, merchantName, merchantHashId, onSelectOrde
               </div>
             )}
             {activeBoard.readyFull.map(renderOrderCard)}
-            {activeBoard.pileOrders.length > 0 && (
+            {activeBoard.pileFrontOrder && activeBoard.hiddenPileOrders.length > 0 && (
               <OrderPile
-                orders={activeBoard.pileOrders}
+                frontOrder={activeBoard.pileFrontOrder}
+                waitingCount={activeBoard.hiddenPileOrders.length}
                 highlightedIds={highlightedIds}
                 elapsedTick={elapsedTick}
                 onSelectOrder={onSelectOrder}
@@ -285,22 +289,23 @@ function OrdersListPage({ merchantId, merchantName, merchantHashId, onSelectOrde
 // ─── Order pile (overflow beyond first 10 FIFO) ───
 
 const OrderPile = React.memo(function OrderPile({
-  orders,
+  frontOrder,
+  waitingCount,
   highlightedIds,
   elapsedTick,
   onSelectOrder,
   t,
 }: {
-  orders: any[];
+  frontOrder: any;
+  waitingCount: number;
   highlightedIds: Set<number>;
   elapsedTick?: number;
   onSelectOrder: (id: number) => void;
   t: (key: string, options?: Record<string, unknown>) => string;
 }) {
-  const topOrder = orders[0];
-  const stackLayers = Math.min(orders.length - 1, 3);
+  const stackLayers = Math.min(waitingCount, 3);
 
-  const handleActivate = () => onSelectOrder(topOrder.orderId);
+  const handleActivate = () => onSelectOrder(frontOrder.orderId);
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault();
@@ -315,7 +320,7 @@ const OrderPile = React.memo(function OrderPile({
       onKeyDown={handleKeyDown}
       role="button"
       tabIndex={0}
-      aria-label={t('merchant.kdsOrderPile', { count: orders.length })}
+      aria-label={t('merchant.kdsOrderPile', { count: waitingCount })}
     >
       <div className="OrderPile__stack">
         {Array.from({ length: stackLayers }).map((_, index) => (
@@ -328,16 +333,16 @@ const OrderPile = React.memo(function OrderPile({
         ))}
         <div className="OrderPile__layer OrderPile__layer--front">
           <OrderCard
-            order={topOrder}
-            highlighted={highlightedIds.has(topOrder.orderId)}
+            order={frontOrder}
+            highlighted={highlightedIds.has(frontOrder.orderId)}
             elapsedTick={elapsedTick}
-            onClick={() => onSelectOrder(topOrder.orderId)}
+            onClick={() => onSelectOrder(frontOrder.orderId)}
             t={t}
             inPile
           />
         </div>
       </div>
-      <div className="OrderPile__label">{t('merchant.kdsOrderPile', { count: orders.length })}</div>
+      <div className="OrderPile__label">{t('merchant.kdsOrderPile', { count: waitingCount })}</div>
     </div>
   );
 });

--- a/src/client/locales/en.yaml
+++ b/src/client/locales/en.yaml
@@ -108,7 +108,7 @@ merchant:
   reconnecting: "Reconnecting"
   moreItems: "more..."
   kdsReadyDivider: "Ready for Pickup / Delivery"
-  kdsOrderPile: "+{{count}} more orders"
+  kdsOrderPile: "{{count}} more orders waiting"
   backToOrders: "← Back to Orders"
   orderNum: "Order #{{id}}"
   customer: "Customer"

--- a/src/client/locales/ms.yaml
+++ b/src/client/locales/ms.yaml
@@ -107,7 +107,7 @@ merchant:
   reconnecting: "Menyambung semula"
   moreItems: "lagi..."
   kdsReadyDivider: "Sedia untuk Ambil / Penghantaran"
-  kdsOrderPile: "+{{count}} pesanan lagi"
+  kdsOrderPile: "{{count}} pesanan lagi menunggu"
   backToOrders: "← Kembali ke Pesanan"
   orderNum: "Pesanan #{{id}}"
   customer: "Pelanggan"

--- a/src/client/locales/zh.yaml
+++ b/src/client/locales/zh.yaml
@@ -108,7 +108,7 @@ merchant:
   reconnecting: "重新连接中"
   moreItems: "更多..."
   kdsReadyDivider: "待取餐 / 待配送"
-  kdsOrderPile: "另有 {{count}} 单"
+  kdsOrderPile: "另有 {{count}} 单等待处理"
   backToOrders: "← 返回订单"
   orderNum: "订单 #{{id}}"
   customer: "客户"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Show one real order ticket as the overflow stack front card.
- Represent hidden overflow orders as decorative ticket layers underneath the front ticket instead of rendering miniature stacked order tickets.
- Change overflow copy to `N more orders waiting`.
- Bump deploy version to `0.10.0`.

## Tests
- `pnpm run build`
- `pnpm test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2d13c3ac-db2c-44dc-a016-7a9d3910e2c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2d13c3ac-db2c-44dc-a016-7a9d3910e2c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

