### PR TITLE
Replace overflow order stack with text notice

### DIFF
--- a/src/client/css/pages/MerchantRoutes.css
+++ b/src/client/css/pages/MerchantRoutes.css
@@ -294,9 +294,9 @@
     flex: 1 1 100%;
   }
 
-  .OrderPile {
-    flex: 0 0 calc((100% - 16px) / 3);
-    width: calc((100% - 16px) / 3);
+  .OrdersGrid__overflow-notice {
+    flex: 0 0 100%;
+    width: 100%;
     box-sizing: border-box;
   }
 
@@ -942,48 +942,10 @@
   color: #00a152;
 }
 
-.OrderPile {
-  position: relative;
-  cursor: pointer;
+.OrdersGrid__overflow-notice {
   box-sizing: border-box;
   width: 100%;
-  overflow: visible;
-}
-
-.OrderPile__stack {
-  position: relative;
-  margin-bottom: 20px;
-}
-
-.OrderPile__layer--back {
-  position: absolute;
-  inset: 0;
-  border-radius: 10px;
-  border: 2px solid #333;
-  background: #101010;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.35);
-  transform:
-    translateY(calc(var(--pile-layer, 1) * 7px))
-    scale(calc(1 - (var(--pile-layer, 1) * 0.018)));
-  transform-origin: top center;
-  z-index: calc(10 - var(--pile-layer, 1));
-}
-
-.OrderPile__layer--front {
-  position: relative;
-  z-index: 20;
-}
-
-.OrderPile__layer--front .OrderCard {
-  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.45);
-}
-
-.OrderCard--in-pile {
-  pointer-events: none;
-}
-
-.OrderPile__label {
-  margin-top: 4px;
+  padding: 6px 8px 10px;
   text-align: center;
   color: #00e5ff;
   font-size: 0.85rem;
@@ -992,12 +954,7 @@
   letter-spacing: 0.04em;
 }
 
-.Merchant--theme-light .OrderPile__layer--back {
-  background: #ececec;
-  border-color: #ccc;
-}
-
-.Merchant--theme-light .OrderPile__label {
+.Merchant--theme-light .OrdersGrid__overflow-notice {
   color: #00838f;
 }
 

--- a/src/client/js/pages/MerchantRoutes.tsx
+++ b/src/client/js/pages/MerchantRoutes.tsx
@@ -106,16 +106,13 @@ function sortFifo(a: any, b: any) {
 
 function splitActiveBoard(awaitingPreparing: any[], ready: any[], limit = KDS_FULL_ORDER_LIMIT) {
   const globalFifo = [...awaitingPreparing, ...ready].sort(sortFifo);
-  const hasOverflow = globalFifo.length > limit;
-  const visibleFullLimit = hasOverflow ? Math.max(limit - 1, 0) : limit;
-  const fullIds = new Set(globalFifo.slice(0, visibleFullLimit).map((order) => order.orderId));
-  const pileFrontOrder = hasOverflow ? globalFifo[visibleFullLimit] : null;
-  const hiddenPileOrders = hasOverflow ? globalFifo.slice(visibleFullLimit + 1) : [];
+  const fullIds = new Set(globalFifo.slice(0, limit).map((order) => order.orderId));
+  const overflowCount = Math.max(globalFifo.length - limit, 0);
   const activeFull = awaitingPreparing.filter((order) => fullIds.has(order.orderId));
   const readyFull = ready.filter((order) => fullIds.has(order.orderId));
   const showDivider = activeFull.length > 0 && ready.length > 0;
 
-  return { activeFull, readyFull, pileFrontOrder, hiddenPileOrders, showDivider };
+  return { activeFull, readyFull, overflowCount, showDivider };
 }
 
 function todayISO() {
@@ -250,22 +247,17 @@ function OrdersListPage({ merchantId, merchantName, merchantHashId, onSelectOrde
         ) : statusFilter === 'active' ? (
           <>
             {activeBoard.activeFull.map(renderOrderCard)}
+            {activeBoard.overflowCount > 0 && (
+              <div className="OrdersGrid__overflow-notice">
+                {t('merchant.kdsOrderPile', { count: activeBoard.overflowCount })}
+              </div>
+            )}
             {activeBoard.showDivider && (
               <div className="OrdersGrid__divider" role="separator" aria-label={t('merchant.kdsReadyDivider')}>
                 <span className="OrdersGrid__divider-label">{t('merchant.kdsReadyDivider')}</span>
               </div>
             )}
             {activeBoard.readyFull.map(renderOrderCard)}
-            {activeBoard.pileFrontOrder && activeBoard.hiddenPileOrders.length > 0 && (
-              <OrderPile
-                frontOrder={activeBoard.pileFrontOrder}
-                waitingCount={activeBoard.hiddenPileOrders.length}
-                highlightedIds={highlightedIds}
-                elapsedTick={elapsedTick}
-                onSelectOrder={onSelectOrder}
-                t={t}
-              />
-            )}
           </>
         ) : (
           <div className="OrdersGrid__section OrdersGrid__section--canceled">
@@ -286,75 +278,14 @@ function OrdersListPage({ merchantId, merchantName, merchantHashId, onSelectOrde
   );
 }
 
-// ─── Order pile (overflow beyond first 10 FIFO) ───
-
-const OrderPile = React.memo(function OrderPile({
-  frontOrder,
-  waitingCount,
-  highlightedIds,
-  elapsedTick,
-  onSelectOrder,
-  t,
-}: {
-  frontOrder: any;
-  waitingCount: number;
-  highlightedIds: Set<number>;
-  elapsedTick?: number;
-  onSelectOrder: (id: number) => void;
-  t: (key: string, options?: Record<string, unknown>) => string;
-}) {
-  const stackLayers = Math.min(waitingCount, 3);
-
-  const handleActivate = () => onSelectOrder(frontOrder.orderId);
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'Enter' || e.key === ' ') {
-      e.preventDefault();
-      handleActivate();
-    }
-  };
-
-  return (
-    <div
-      className="OrderPile"
-      onClick={handleActivate}
-      onKeyDown={handleKeyDown}
-      role="button"
-      tabIndex={0}
-      aria-label={t('merchant.kdsOrderPile', { count: waitingCount })}
-    >
-      <div className="OrderPile__stack">
-        {Array.from({ length: stackLayers }).map((_, index) => (
-          <div
-            key={`layer-${index}`}
-            className="OrderPile__layer OrderPile__layer--back"
-            style={{ ['--pile-layer' as string]: index + 1 }}
-            aria-hidden="true"
-          />
-        ))}
-        <div className="OrderPile__layer OrderPile__layer--front">
-          <OrderCard
-            order={frontOrder}
-            highlighted={highlightedIds.has(frontOrder.orderId)}
-            elapsedTick={elapsedTick}
-            onClick={() => onSelectOrder(frontOrder.orderId)}
-            t={t}
-            inPile
-          />
-        </div>
-      </div>
-      <div className="OrderPile__label">{t('merchant.kdsOrderPile', { count: waitingCount })}</div>
-    </div>
-  );
-});
-
 // ─── Order Card (memoized for scroll perf on low-end devices) ───
 
-const OrderCard = React.memo(function OrderCard({ order, highlighted, elapsedTick, onClick, t, inPile }: { order: any; highlighted?: boolean; elapsedTick?: number; onClick?: () => void; t: (key: string) => string; inPile?: boolean }) {
+const OrderCard = React.memo(function OrderCard({ order, highlighted, elapsedTick, onClick, t }: { order: any; highlighted?: boolean; elapsedTick?: number; onClick?: () => void; t: (key: string) => string }) {
   const status: OrderStatus = order.status;
   const elapsed = getElapsed(order.createdAt, t, elapsedTick);
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (!onClick || inPile) return;
+    if (!onClick) return;
     if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault();
       onClick();
@@ -363,11 +294,11 @@ const OrderCard = React.memo(function OrderCard({ order, highlighted, elapsedTic
 
   return (
     <div
-      className={`OrderCard OrderCard--${status}${highlighted ? ' OrderCard--highlight' : ''}${inPile ? ' OrderCard--in-pile' : ''}`}
-      onClick={inPile ? undefined : onClick}
-      onKeyDown={inPile ? undefined : handleKeyDown}
-      role={inPile ? undefined : 'button'}
-      tabIndex={inPile ? -1 : 0}
+      className={`OrderCard OrderCard--${status}${highlighted ? ' OrderCard--highlight' : ''}`}
+      onClick={onClick}
+      onKeyDown={handleKeyDown}
+      role="button"
+      tabIndex={0}
       aria-label={`View order #${order.displayNumber ?? order.orderId} from ${order.customerName}`}
     >
       <div className="OrderCard__top">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Render the first 10 active-board orders as normal tickets.
- Remove the overflow ticket stack component and decorative layers.
- Show a full-width `N more orders waiting` notice before the Ready divider, keeping it in the active-order area.

## Tests
- `pnpm run build`
- `pnpm test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2d13c3ac-db2c-44dc-a016-7a9d3910e2c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2d13c3ac-db2c-44dc-a016-7a9d3910e2c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

