### PR TITLE
Limit active ticket overflow independently

### DIFF
--- a/src/client/js/pages/MerchantRoutes.tsx
+++ b/src/client/js/pages/MerchantRoutes.tsx
@@ -105,11 +105,9 @@ function sortFifo(a: any, b: any) {
 }
 
 function splitActiveBoard(awaitingPreparing: any[], ready: any[], limit = KDS_FULL_ORDER_LIMIT) {
-  const globalFifo = [...awaitingPreparing, ...ready].sort(sortFifo);
-  const fullIds = new Set(globalFifo.slice(0, limit).map((order) => order.orderId));
-  const overflowCount = Math.max(globalFifo.length - limit, 0);
-  const activeFull = awaitingPreparing.filter((order) => fullIds.has(order.orderId));
-  const readyFull = ready.filter((order) => fullIds.has(order.orderId));
+  const activeFull = awaitingPreparing.slice(0, limit);
+  const readyFull = ready;
+  const overflowCount = Math.max(awaitingPreparing.length - limit, 0);
   const showDivider = activeFull.length > 0 && ready.length > 0;
 
   return { activeFull, readyFull, overflowCount, showDivider };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Limit only active/preparing tickets to the first 10 visible cards.
- Keep ready-for-pickup/delivery orders out of the active ticket cap.
- Render the `N more orders waiting` notice immediately after the last visible active ticket, before the Ready divider.

## Tests
- `pnpm run build`
- `pnpm test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2d13c3ac-db2c-44dc-a016-7a9d3910e2c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2d13c3ac-db2c-44dc-a016-7a9d3910e2c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

