### PR TITLE
Make order ticket grid flexible

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sqc-nodejs-demo",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "private": true,
   "main": "src/server/index.js",
   "scripts": {

--- a/src/client/css/pages/MerchantRoutes.css
+++ b/src/client/css/pages/MerchantRoutes.css
@@ -69,9 +69,12 @@
 /* ===== Orders List — Mobile: single column scroll, Desktop: grid ===== */
 
 .OrdersGrid {
+  --order-ticket-gap: 12px;
+  --order-ticket-min-width: 220px;
+  --order-ticket-max-width: 320px;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: var(--order-ticket-gap);
   padding: 12px;
   min-height: 100vh;
   min-height: 100dvh;
@@ -138,7 +141,8 @@
 .OrdersGrid__cards {
   display: grid;
   grid-template-columns: 1fr;
-  gap: 12px;
+  gap: var(--order-ticket-gap);
+  justify-items: center;
   flex: 1;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;
@@ -160,9 +164,10 @@
   }
 }
 
-/* Tablet+: KDS 3-column scrollable masonry-style tickets */
+/* Tablet+: KDS flexible ticket grid, capped at five 320px columns */
 @media (min-width: 768px) {
   .OrdersGrid {
+    --order-ticket-gap: 8px;
     height: 100dvh;
     max-height: 100dvh;
     display: flex;
@@ -185,12 +190,16 @@
   }
 
   .OrdersGrid__cards {
-    display: flex;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, var(--order-ticket-min-width)), var(--order-ticket-max-width)));
     flex: 1 1 auto;
-    flex-wrap: wrap;
     align-content: flex-start;
     align-items: stretch;
-    gap: 8px;
+    justify-content: center;
+    gap: var(--order-ticket-gap);
+    width: 100%;
+    max-width: calc((var(--order-ticket-max-width) * 5) + (var(--order-ticket-gap) * 4));
+    margin: 0 auto;
     overflow-x: hidden;
     overflow-y: auto;
     min-height: 0;
@@ -211,8 +220,8 @@
 
   .OrderCard {
     box-sizing: border-box;
-    flex: 0 0 calc((100% - 16px) / 3);
-    width: calc((100% - 16px) / 3);
+    width: 100%;
+    max-width: var(--order-ticket-max-width);
     padding: 8px 10px;
     min-height: 0;
     height: auto;
@@ -291,18 +300,16 @@
   }
 
   .OrdersGrid__empty {
-    flex: 1 1 100%;
+    grid-column: 1 / -1;
   }
 
   .OrdersGrid__overflow-notice {
-    flex: 0 0 100%;
-    width: 100%;
+    grid-column: 1 / -1;
     box-sizing: border-box;
   }
 
   .OrdersGrid__divider {
-    flex: 0 0 100%;
-    width: 100%;
+    grid-column: 1 / -1;
   }
 
   .OrderDetail__meta-comment {
@@ -317,6 +324,8 @@
   border-radius: 12px;
   border: 3px solid #333;
   padding: 16px;
+  width: 100%;
+  max-width: var(--order-ticket-max-width);
   min-height: 120px;
   cursor: pointer;
   display: flex;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Set order ticket cards to a 320px max width.
- Replace the fixed 3-column tablet/desktop layout with an auto-fit grid.
- Cap the ticket grid at five columns while allowing 1-5 columns based on screen width.
- Bump deploy version to `0.11.0`.

## Tests
- `pnpm run build`
- `pnpm test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2d13c3ac-db2c-44dc-a016-7a9d3910e2c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2d13c3ac-db2c-44dc-a016-7a9d3910e2c1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

