### PR TITLE
Fix Vite build: broken shared import paths for kitchen print

### DIFF
--- a/src/client/js/hooks/useKitchenAutoPrint.ts
+++ b/src/client/js/hooks/useKitchenAutoPrint.ts
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
-import type { OrderStreamPayload } from '../../shared/order_events';
-import { shouldAutoPrintKitchenTicket } from '../../shared/kitchen_print';
+import type { OrderStreamPayload } from '../../../shared/order_events';
+import { shouldAutoPrintKitchenTicket } from '../../../shared/kitchen_print';
 import { triggerKitchenTicketAutoPrint } from '../lib/kitchenTicketPrint';
 
 /**

--- a/src/client/js/lib/kitchenTicketPrint.ts
+++ b/src/client/js/lib/kitchenTicketPrint.ts
@@ -1,4 +1,4 @@
-import { merchantKitchenTicketPath } from '../../shared/merchant_dashboard';
+import { merchantKitchenTicketPath } from '../../../shared/merchant_dashboard';
 
 const IFRAME_CLEANUP_MS = 60_000;
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Root cause

Railway staging has been returning **502** since the kitchen print merge (`9e6c525` / `719dbfd`). GitHub deployment status: **Deployment failed**.

Local reproduction:

```
Could not resolve "../../shared/kitchen_print" from "src/client/js/hooks/useKitchenAutoPrint.ts"
Could not resolve "../../shared/merchant_dashboard" from "src/client/js/lib/kitchenTicketPrint.ts"
```

Those files live under `src/client/js/hooks/` and `src/client/js/lib/`, so `../../shared` resolves to `src/client/shared` (missing). Correct path is `../../../shared/...`.

Unit tests still passed because Mocha/tsx did not hit the Vite client bundle path.

## Fix

- `useKitchenAutoPrint.ts` → `../../../shared/order_events` and `../../../shared/kitchen_print`
- `kitchenTicketPrint.ts` → `../../../shared/merchant_dashboard`

Verified: `pnpm run build` succeeds and kitchen ticket chunk is emitted.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-96d6c998-659b-4a14-bc4b-bf45541bbc6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-96d6c998-659b-4a14-bc4b-bf45541bbc6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

